### PR TITLE
fix(ocado): mark provider as broken until rebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Built for agent frameworks like [OpenClaw](https://github.com/claw-labs/openclaw
 ## Supported Supermarkets
 
 - ✅ **Sainsbury's** - UK-wide delivery, full API coverage
-- ✅ **Ocado** - London & South England, complete integration
+- ⚠️ **Ocado** - **Currently broken.** Ocado migrated to a client-side React SPA and the previous endpoints have been removed. Provider is disabled and will throw a clear error until rebuilt. Tracking: [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5)
 - ✅ **Tesco** - UK-wide delivery, full API coverage (search, basket, checkout)
 - 🔜 **Asda** - Planned Q2 2026
 - 🔜 **Morrisons** - Planned Q2 2026
@@ -469,12 +469,13 @@ uk-grocery-cli/
 ### Authentication
 - **Sainsbury's**: SMS 2FA required on every fresh login — session lasts ~7 days
 - **Tesco**: Akamai bot detection can block automated login. Use `import-session` (manual browser login → Cookie Editor export → `groc --provider tesco import-session --file cookies.json`) as the reliable path. Session lasts ~7 days.
-- **Ocado**: Standard email/password login, sessions stable
+- **Ocado**: ⚠️ Disabled. Site moved to React SPA, previous endpoints removed. See [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5).
 
 ### API Coverage
-- ✅ **Working**: Search, basket management, product data (all three providers)
+- ✅ **Working**: Search, basket management, product data — Sainsbury's and Tesco
 - ✅ **Working**: Tesco delivery slots + checkout (browser-automated, requires manual payment confirmation)
-- ⚠️ **Experimental**: Sainsbury's/Ocado checkout flow (needs real-world testing)
+- ⚠️ **Experimental**: Sainsbury's checkout flow (needs real-world testing)
+- ⚠️ **Broken**: Entire Ocado provider — endpoints removed by Ocado, awaiting rebuild ([#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5))
 - 🔜 **Coming**: Order tracking, substitutions, favourites
 
 Some endpoints are still being reverse-engineered. Contributions welcome.
@@ -507,7 +508,7 @@ Open an issue or PR.
 ### v2.0 (Current)
 - ✅ Multi-provider architecture
 - ✅ Sainsbury's provider (full coverage)
-- ✅ Ocado provider (full coverage)
+- ⚠️ Ocado provider (disabled — see [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5))
 - ✅ Tesco provider (full coverage — search, basket, checkout, slots, staples)
 
 ### v2.1 (Current)

--- a/skills/ocado.md
+++ b/skills/ocado.md
@@ -13,6 +13,8 @@ allowed-tools: Bash({baseDir}/node:*), Bash(npm:run:groc:*)
 
 # Ocado Groceries Skill
 
+> ⚠️ **This provider is currently disabled.** Ocado migrated to a client-side React SPA and the previous REST endpoints have been removed. Every command below will throw a clear error until the provider is rebuilt against verified endpoints (or via a Playwright renderer). Tracking: [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5). Use `--provider sainsburys` or `--provider tesco` in the meantime.
+
 Search products, manage basket, and book delivery at Ocado.
 
 **Location:** `{baseDir}`

--- a/src/providers/ocado.ts
+++ b/src/providers/ocado.ts
@@ -1,270 +1,81 @@
-import axios, { AxiosInstance } from 'axios';
-import { GroceryProvider, Product, Basket, DeliverySlot, Order, SearchOptions, BasketItem } from './types';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { GroceryProvider, Product, Basket, DeliverySlot, Order, SearchOptions } from './types';
 
-const API_BASE = 'https://www.ocado.com/api';
-const SESSION_FILE = path.join(os.homedir(), '.ocado', 'session.json');
+// Ocado migrated to a client-side React SPA. The previous REST endpoints
+// (`/api/search/v1/products`, `/api/trolley/v1/*`, `/api/slots/v1/*`, etc.)
+// return 404 or HTML — they were never a stable public API. Until the
+// provider is rebuilt against verified endpoints (or via a Playwright
+// renderer), every method throws a clear, actionable error rather than
+// pretending to work. Tracking issue: #5.
+const OCADO_BROKEN_MESSAGE =
+  'Ocado provider is currently disabled. The previous REST endpoints have ' +
+  'been removed by Ocado and the provider needs to be rebuilt. ' +
+  'See https://github.com/abracadabra50/uk-grocery-cli/issues/5 for status. ' +
+  'Use --provider sainsburys or --provider tesco in the meantime.';
+
+function ocadoBroken(): never {
+  throw new Error(OCADO_BROKEN_MESSAGE);
+}
 
 export class OcadoProvider implements GroceryProvider {
   readonly name = 'ocado';
-  private client: AxiosInstance;
-  private regionId: string = '9138094d-f307-46aa-a62d-86c8bdaeb4b9'; // Default region
 
-  constructor() {
-    this.client = axios.create({
-      baseURL: API_BASE,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-        'Accept': 'application/json',
-      }
-    });
-
-    // Load session if exists
-    this.loadSession();
-  }
-
-  private loadSession() {
-    try {
-      if (fs.existsSync(SESSION_FILE)) {
-        const session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
-        if (session.cookies) {
-          this.client.defaults.headers.common['Cookie'] = session.cookies;
-        }
-        if (session.regionId) {
-          this.regionId = session.regionId;
-        }
-      }
-    } catch (error) {
-      // Ignore session load errors
-    }
-  }
-
-  private saveSession(cookies: string, regionId?: string) {
-    const dir = path.dirname(SESSION_FILE);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-    fs.writeFileSync(SESSION_FILE, JSON.stringify({
-      cookies,
-      regionId: regionId || this.regionId,
-      savedAt: new Date().toISOString()
-    }), { mode: 0o600 });
-  }
-
-  async login(email: string, password: string): Promise<void> {
-    // Ocado login would use Playwright similar to Sainsbury's
-    // For now, this is a placeholder - needs implementation
-    throw new Error('Ocado login not yet implemented. Use browser session export.');
+  async login(_email: string, _password: string): Promise<void> {
+    ocadoBroken();
   }
 
   async logout(): Promise<void> {
-    if (fs.existsSync(SESSION_FILE)) {
-      fs.unlinkSync(SESSION_FILE);
-    }
-    delete this.client.defaults.headers.common['Cookie'];
+    ocadoBroken();
   }
 
   async isAuthenticated(): Promise<boolean> {
-    try {
-      await this.getBasket();
-      return true;
-    } catch {
-      return false;
-    }
+    return false;
   }
 
-  async search(query: string, options?: SearchOptions): Promise<Product[]> {
-    // Ocado search endpoint
-    const params: any = {
-      searchTerm: query,
-      limit: options?.limit || 24,
-      regionId: this.regionId
-    };
-
-    try {
-      const response = await this.client.get('/search/v1/products', { params });
-      
-      // Map Ocado's response format to our common format
-      return response.data.results?.map((p: any) => ({
-        product_uid: p.id || p.sku,
-        name: p.title || p.name,
-        description: p.description,
-        retail_price: {
-          price: parseFloat(p.price || p.currentPrice || 0)
-        },
-        unit_price: p.unitPrice ? {
-          measure: p.unitPrice.measure,
-          price: parseFloat(p.unitPrice.price)
-        } : undefined,
-        in_stock: p.available !== false && p.inStock !== false,
-        image_url: p.imageUrl || p.image,
-        provider: this.name
-      })) || [];
-    } catch (error: any) {
-      if (error.response?.status === 404) {
-        // Try alternative search endpoint
-        return this.searchAlternative(query, options);
-      }
-      throw error;
-    }
+  async search(_query: string, _options?: SearchOptions): Promise<Product[]> {
+    ocadoBroken();
   }
 
-  private async searchAlternative(query: string, options?: SearchOptions): Promise<Product[]> {
-    // Alternative search using suggestions endpoint
-    const params: any = {
-      searchTerm: query,
-      limit: options?.limit || 24,
-      regionId: this.regionId
-    };
-
-    const response = await this.client.get('/search/v1/suggestions/primary', { params });
-    
-    return response.data.products?.slice(0, options?.limit || 24).map((p: any) => ({
-      product_uid: p.id,
-      name: p.name,
-      description: p.description,
-      retail_price: {
-        price: parseFloat(p.price || 0)
-      },
-      in_stock: true,
-      provider: this.name
-    })) || [];
-  }
-
-  async getProduct(productId: string): Promise<Product> {
-    const response = await this.client.get(`/products/v1/${productId}`);
-    const p = response.data;
-    
-    return {
-      product_uid: p.id,
-      name: p.title || p.name,
-      description: p.description,
-      retail_price: {
-        price: parseFloat(p.price || 0)
-      },
-      unit_price: p.unitPrice ? {
-        measure: p.unitPrice.measure,
-        price: parseFloat(p.unitPrice.price)
-      } : undefined,
-      in_stock: p.available !== false,
-      image_url: p.imageUrl,
-      provider: this.name
-    };
+  async getProduct(_productId: string): Promise<Product> {
+    ocadoBroken();
   }
 
   async getCategories(): Promise<any> {
-    const response = await this.client.get('/categories/v1/tree');
-    return response.data;
+    ocadoBroken();
   }
 
   async getBasket(): Promise<Basket> {
-    // Ocado basket/trolley endpoint
-    const response = await this.client.get('/trolley/v1/basket');
-    const data = response.data;
-    
-    return {
-      items: data.items?.map((p: any) => ({
-        item_id: p.id || p.lineId,
-        product_uid: p.productId || p.sku,
-        name: p.title || p.name,
-        quantity: p.quantity,
-        unit_price: parseFloat(p.unitPrice || p.price || 0),
-        total_price: parseFloat(p.total || (p.quantity * (p.unitPrice || p.price)) || 0)
-      })) || [],
-      total_quantity: data.totalQuantity || data.items?.reduce((sum: number, i: any) => sum + i.quantity, 0) || 0,
-      total_cost: parseFloat(data.total || data.totalCost || 0),
-      provider: this.name
-    };
+    ocadoBroken();
   }
 
-  async addToBasket(productId: string, quantity: number): Promise<void> {
-    await this.client.post('/trolley/v1/items', {
-      productId,
-      quantity
-    });
+  async addToBasket(_productId: string, _quantity: number): Promise<void> {
+    ocadoBroken();
   }
 
-  async updateBasketItem(itemId: string, quantity: number): Promise<void> {
-    await this.client.put(`/trolley/v1/items/${itemId}`, { quantity });
+  async updateBasketItem(_itemId: string, _quantity: number): Promise<void> {
+    ocadoBroken();
   }
 
-  async removeFromBasket(itemId: string): Promise<void> {
-    await this.client.delete(`/trolley/v1/items/${itemId}`);
+  async removeFromBasket(_itemId: string): Promise<void> {
+    ocadoBroken();
   }
 
   async clearBasket(): Promise<void> {
-    const basket = await this.getBasket();
-    await Promise.all(basket.items.map(item => this.removeFromBasket(item.item_id)));
+    ocadoBroken();
   }
 
   async getDeliverySlots(): Promise<DeliverySlot[]> {
-    const response = await this.client.get('/slots/v1/available');
-    
-    return response.data.slots?.map((s: any) => ({
-      slot_id: s.id || s.slotId,
-      start_time: s.startTime || s.start,
-      end_time: s.endTime || s.end,
-      date: s.date,
-      price: parseFloat(s.price || s.deliveryCharge || 0),
-      available: s.available !== false
-    })) || [];
+    ocadoBroken();
   }
 
-  async bookSlot(slotId: string): Promise<void> {
-    await this.client.post('/slots/v1/book', {
-      slotId
-    });
+  async bookSlot(_slotId: string): Promise<void> {
+    ocadoBroken();
   }
 
-  async checkout(): Promise<Order> {
-    const response = await this.client.post('/checkout/v1/place-order');
-    
-    return {
-      order_id: response.data.orderId || response.data.id || 'unknown',
-      status: response.data.status || 'placed',
-      total: parseFloat(response.data.total || 0),
-      items: []
-    };
+  async checkout(_dryRun?: boolean): Promise<Order> {
+    ocadoBroken();
   }
 
   async getOrders(): Promise<Order[]> {
-    try {
-      const endpoints = [
-        '/orders/v1/history',
-        '/order/v1/orders',
-        '/customer/v1/orders'
-      ];
-      
-      for (const endpoint of endpoints) {
-        try {
-          const response = await this.client.get(endpoint);
-          if (response.data && (response.data.orders || response.data.orderHistory)) {
-            const orders = response.data.orders || response.data.orderHistory || [];
-            return orders.map((o: any) => ({
-              order_id: o.id || o.orderId || o.orderNumber,
-              status: o.status || o.orderStatus || 'unknown',
-              total: parseFloat(o.total || o.totalAmount || 0),
-              delivery_slot: o.deliverySlot ? {
-                slot_id: o.deliverySlot.id || '',
-                start_time: o.deliverySlot.startTime || '',
-                end_time: o.deliverySlot.endTime || '',
-                date: o.deliverySlot.date || '',
-                price: parseFloat(o.deliverySlot.price || 0),
-                available: true
-              } : undefined,
-              items: o.items || []
-            }));
-          }
-        } catch (e) {
-          continue;
-        }
-      }
-      
-      return [];
-    } catch (error: any) {
-      return [];
-    }
+    ocadoBroken();
   }
 }


### PR DESCRIPTION
## Summary
- Ocado provider was built on speculative REST endpoints that don't exist (Ocado moved to a client-side React SPA). Search, basket, slots, and checkout all silently fail.
- Replaces the implementation with a clean stub: every method throws a clear, actionable error linking [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5) and pointing users at Sainsbury's / Tesco.
- Updates README (supported stores, known limitations, API coverage, roadmap) and `skills/ocado.md` to reflect actual status — no more "✅ complete integration" claims for something that doesn't work.
- `tsc --noEmit` clean. Provider factory and `compareProduct` continue to work — Ocado just returns an error in the comparison output instead of bogus data.

## Why ship now
This is the minimum honest fix. A real rebuild (Playwright renderer or reverse-engineered internal API) is still tracked in #5. Until then, users were being misled by the README and getting silent failures from the CLI — this PR stops both.

## Test plan
- [ ] \`npx tsc --noEmit\` passes
- [ ] \`groc --provider ocado search "milk"\` throws the new error message
- [ ] \`groc --provider sainsburys search "milk"\` still works
- [ ] \`groc --provider tesco search "milk"\` still works
- [ ] \`grocery_compare\` MCP tool returns Ocado as \`error\` rather than crashing the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)