### PR TITLE
add a JSON HTTP API for agents with no filesystem access

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+dist
+.git
+.gitignore
+Dockerfile
+.dockerignore
+*.log
+.env
+.env.*
+.sainsburys
+.tesco
+.ocado
+*_response.json
+tmp
+temp
+coverage
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ dist/
 .ocado/
 
 # Build artifacts
-*.js
 *.js.map
 !jest.config.js
 !setup.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:24-slim
+
+WORKDIR /app
+
+ENV GROC_API_HOST=0.0.0.0
+ENV GROC_API_PORT=7876
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+
+EXPOSE 7876
+CMD ["npm", "run", "api"]

--- a/README.md
+++ b/README.md
@@ -210,6 +210,73 @@ All tools accept a `provider` parameter: `sainsburys` (default), `ocado`, or `te
 
 See [SKILL.md](SKILL.md) for full MCP reference and per-supermarket skill files in [`skills/`](skills/).
 
+### Lightweight HTTP API
+
+Some agents have access to the local network but not the filesystem.
+
+For those cases, it's useful to have a tiny JSON HTTP API that replicates the CLI behaviour:
+
+```bash
+npm run api
+# or, recommended if exposing beyond your own shell:
+GROC_API_TOKEN=devsecret npm run api
+```
+
+Defaults:
+
+- Host: `127.0.0.1` (`GROC_API_HOST`)
+- Port: `7876` (`GROC_API_PORT`)
+- Provider: `sainsburys` (`GROC_PROVIDER`)
+
+Endpoints:
+
+```bash
+GET /search?q=milk&limit=24
+GET /add?id=1234&qty=1        # also accepts /add?q=1234
+GET /remove?id=<item-id>      # basket item ID, not product ID
+GET /update?id=<item-id>&qty=2
+GET /basket
+GET /favourites?limit=50       # if provider supports favourites
+GET /fav-search?q=milk&limit=24 # if provider supports favourites
+```
+
+Example with token auth:
+
+```bash
+curl -H 'Authorization: Bearer devsecret' 'http://127.0.0.1:7876/search?q=milk'
+```
+
+### Docker HTTP API
+
+Build the lightweight API image:
+
+```bash
+docker build -t uk-grocery-api .
+```
+
+Run it with your Sainsbury's auth file mounted read-only. The app expects the session at `~/.sainsburys/session.json`; inside this image that is `/root/.sainsburys/session.json`.
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:7876:7876 \
+  -v "$HOME/.sainsburys:/root/.sainsburys:ro" \
+  uk-grocery-api
+```
+
+With optional API token auth:
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:7876:7876 \
+  -e GROC_API_TOKEN=devsecret \
+  -v "$HOME/.sainsburys:/root/.sainsburys:ro" \
+  uk-grocery-api
+
+curl -H 'Authorization: Bearer devsecret' 'http://127.0.0.1:7876/basket'
+```
+
+Keep the host publish address as `127.0.0.1:7876:7876` unless you intentionally want other machines to reach the API.
+
 ## Smart Shopping Features
 
 The CLI provides product data. Your agent makes intelligent decisions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uk-grocery-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uk-grocery-cli",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -17,6 +17,7 @@
       },
       "bin": {
         "groc": "dist/cli.js",
+        "groc-api": "dist/http-server.js",
         "groc-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "main": "dist/cli.js",
   "bin": {
     "groc": "./dist/cli.js",
-    "groc-mcp": "./dist/mcp-server.js"
+    "groc-mcp": "./dist/mcp-server.js",
+    "groc-api": "./dist/http-server.js"
   },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts",
     "groc": "tsx src/cli.ts",
+    "api": "tsx src/http-server.ts",
     "mcp": "tsx src/mcp-server.ts",
     "setup": "./setup.sh"
   },

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: grocery-api
+description: Use the local groc HTTP API to search Sainsbury's groceries, search favourites, add/update/remove basket items, and view basket.
+allowed-tools: Bash(node:skills/api/wrapper.js:*)
+---
+
+# Grocery API Skill
+
+Use this skill when the user asks about Sainsbury's groceries, favourites, searching products, adding/updating/removing basket items, or viewing the basket.
+
+The local API must already be running on port `7876`:
+
+```bash
+GROC_API_PORT=7876 npm run api
+```
+
+## Commands
+
+Run from the repo root:
+
+```bash
+node skills/api/wrapper.js fav-search "milk"
+node skills/api/wrapper.js search "milk"
+node skills/api/wrapper.js favourites
+node skills/api/wrapper.js basket
+node skills/api/wrapper.js add <product-id> [qty]
+node skills/api/wrapper.js remove <item-id>
+node skills/api/wrapper.js update <item-id> <qty>
+```
+
+All commands return JSON from the local API.
+
+## Add-to-basket workflow
+
+When the user asks to add an item to the basket:
+
+1. First search favourites:
+
+   ```bash
+   node skills/api/wrapper.js fav-search "USER ITEM"
+   ```
+
+2. If there is a clear favourite result that matches the user's intent, add it directly:
+
+   ```bash
+   node skills/api/wrapper.js add <product-id> [qty]
+   ```
+
+3. If there are multiple plausible favourite results, ask the user which one to add. Include names, prices, and product IDs.
+
+4. If there are no good favourite matches, or if the user explicitly asks to look outside favourites, use regular search:
+
+   ```bash
+   node skills/api/wrapper.js search "USER ITEM"
+   ```
+
+5. For regular search results, always confirm with the user before adding anything to the basket.
+
+6. After adding, show or summarize the basket:
+
+   ```bash
+   node skills/api/wrapper.js basket
+   ```
+
+## Remove/update workflow
+
+When the user asks to remove or update an item:
+
+1. First inspect the basket to get basket item IDs:
+
+   ```bash
+   node skills/api/wrapper.js basket
+   ```
+
+2. Use the basket `item_id`, not the product ID:
+
+   ```bash
+   node skills/api/wrapper.js remove <item-id>
+   node skills/api/wrapper.js update <item-id> <qty>
+   ```
+
+3. If the item to change is ambiguous, ask the user which basket item they mean.
+
+4. After removing or updating, show or summarize the basket.
+
+## Notes
+
+- Prefer favourites over regular search for add requests.
+- Do not add ambiguous items without asking.
+- Do not use regular search additions without confirmation.
+- Use the `product_uid` as the product ID for `add`.
+- Use the basket `item_id` for `remove` and `update`.

--- a/skills/api/wrapper.js
+++ b/skills/api/wrapper.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+// Tiny wrapper for the local groc HTTP API.
+// API server expected at: http://127.0.0.1:7876
+
+const API = 'http://127.0.0.1:7876';
+const [cmd, ...args] = process.argv.slice(2);
+
+async function call(path, params = {}) {
+  const url = new URL(path, API);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') url.searchParams.set(key, String(value));
+  }
+
+  const res = await fetch(url);
+  const body = await res.text();
+
+  if (!res.ok) {
+    console.error(body || `HTTP ${res.status}`);
+    process.exit(1);
+  }
+
+  console.log(body);
+}
+
+switch (cmd) {
+  case 'search':
+    await call('/search', { q: args.join(' ') });
+    break;
+
+  case 'fav-search':
+    await call('/fav-search', { q: args.join(' ') });
+    break;
+
+  case 'favourites':
+  case 'favorites':
+    await call('/favourites');
+    break;
+
+  case 'basket':
+    await call('/basket');
+    break;
+
+  case 'add':
+    await call('/add', { id: args[0], qty: args[1] || 1 });
+    break;
+
+  case 'remove':
+    await call('/remove', { id: args[0] });
+    break;
+
+  case 'update':
+    await call('/update', { id: args[0], qty: args[1] });
+    break;
+
+  default:
+    console.error(`Usage:
+  node skills/api/wrapper.js search "milk"
+  node skills/api/wrapper.js fav-search "milk"
+  node skills/api/wrapper.js favourites
+  node skills/api/wrapper.js basket
+  node skills/api/wrapper.js add <product-id> [qty]
+  node skills/api/wrapper.js remove <item-id>
+  node skills/api/wrapper.js update <item-id> <qty>
+`);
+    process.exit(1);
+}

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import http from 'node:http';
+import { URL } from 'node:url';
+import { ProviderFactory, ProviderName } from './providers';
+import type { GroceryProvider, SearchOptions } from './providers/types';
+
+type FavouritesProvider = GroceryProvider & {
+  getFavourites?: (options?: SearchOptions) => Promise<unknown[]>;
+  searchFavourites?: (query: string, options?: SearchOptions) => Promise<unknown[]>;
+};
+
+const host = process.env.GROC_API_HOST || '127.0.0.1';
+const port = parsePort(process.env.GROC_API_PORT || '7876');
+const defaultProvider = (process.env.GROC_PROVIDER || 'sainsburys') as ProviderName;
+const apiToken = process.env.GROC_API_TOKEN;
+
+function parsePort(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new Error(`Invalid GROC_API_PORT: ${value}`);
+  }
+  return parsed;
+}
+
+function parsePositiveInt(value: string | null, name: string, defaultValue: number): number {
+  if (value === null || value === '') return defaultValue;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function getProvider(url: URL): GroceryProvider {
+  const providerName = (url.searchParams.get('provider') || defaultProvider) as ProviderName;
+  return ProviderFactory.create(providerName);
+}
+
+function sendJson(res: http.ServerResponse, status: number, data: unknown): void {
+  const body = JSON.stringify(data, null, 2);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(body);
+}
+
+function requireQuery(url: URL, name: string): string {
+  const value = url.searchParams.get(name);
+  if (!value) throw Object.assign(new Error(`Missing query parameter: ${name}`), { statusCode: 400 });
+  return value;
+}
+
+function checkAuth(req: http.IncomingMessage): boolean {
+  if (!apiToken) return true;
+  return req.headers.authorization === `Bearer ${apiToken}`;
+}
+
+async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (!checkAuth(req)) {
+    return sendJson(res, 401, { error: 'Unauthorized' });
+  }
+
+  const url = new URL(req.url || '/', `http://${req.headers.host || `${host}:${port}`}`);
+
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  if (url.pathname === '/' || url.pathname === '/health') {
+    return sendJson(res, 200, {
+      ok: true,
+      provider: url.searchParams.get('provider') || defaultProvider,
+      endpoints: [
+        '/search?q=',
+        '/add?id=&qty=',
+        '/remove?id=',
+        '/update?id=&qty=',
+        '/basket',
+        '/favourites',
+        '/fav-search?q='
+      ],
+    });
+  }
+
+  const provider = getProvider(url);
+
+  if (url.pathname === '/search') {
+    const q = requireQuery(url, 'q');
+    const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit', 24);
+    const products = await provider.search(q, { limit });
+    return sendJson(res, 200, { products });
+  }
+
+  if (url.pathname === '/add') {
+    const id = url.searchParams.get('id') || url.searchParams.get('q');
+    if (!id) throw Object.assign(new Error('Missing query parameter: id'), { statusCode: 400 });
+    const qty = parsePositiveInt(url.searchParams.get('qty'), 'qty', 1);
+    await provider.addToBasket(id, qty);
+    return sendJson(res, 200, { ok: true, provider: provider.name, product_id: id, quantity: qty });
+  }
+
+  if (url.pathname === '/remove') {
+    const id = url.searchParams.get('id') || url.searchParams.get('q');
+    if (!id) throw Object.assign(new Error('Missing query parameter: id'), { statusCode: 400 });
+    await provider.removeFromBasket(id);
+    return sendJson(res, 200, { ok: true, provider: provider.name, item_id: id });
+  }
+
+  if (url.pathname === '/update') {
+    const id = url.searchParams.get('id') || url.searchParams.get('q');
+    if (!id) throw Object.assign(new Error('Missing query parameter: id'), { statusCode: 400 });
+    const qty = parsePositiveInt(url.searchParams.get('qty'), 'qty', 1);
+    await provider.updateBasketItem(id, qty);
+    return sendJson(res, 200, { ok: true, provider: provider.name, item_id: id, quantity: qty });
+  }
+
+  if (url.pathname === '/basket') {
+    return sendJson(res, 200, await provider.getBasket());
+  }
+
+  if (url.pathname === '/favourites' || url.pathname === '/favorites') {
+    const favouritesProvider = provider as FavouritesProvider;
+    if (typeof favouritesProvider.getFavourites !== 'function') {
+      return sendJson(res, 501, { error: `Provider "${provider.name}" does not support favourites` });
+    }
+    const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit', 50);
+    const products = await favouritesProvider.getFavourites({ limit });
+    return sendJson(res, 200, { products });
+  }
+
+  if (url.pathname === '/fav-search' || url.pathname === '/favorite-search') {
+    const favouritesProvider = provider as FavouritesProvider;
+    if (typeof favouritesProvider.searchFavourites !== 'function') {
+      return sendJson(res, 501, { error: `Provider "${provider.name}" does not support favourite search` });
+    }
+    const q = requireQuery(url, 'q');
+    const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit', 24);
+    const products = await favouritesProvider.searchFavourites(q, { limit });
+    return sendJson(res, 200, { products });
+  }
+
+  return sendJson(res, 404, { error: 'Not found' });
+}
+
+const server = http.createServer((req, res) => {
+  handleRequest(req, res).catch((error: any) => {
+    const status = Number.isInteger(error?.statusCode) ? error.statusCode : 500;
+    sendJson(res, status, { error: error?.message || 'Internal server error' });
+  });
+});
+
+server.listen(port, host, () => {
+  console.log(`groc API listening on http://${host}:${port}`);
+  console.log(`Provider: ${defaultProvider}`);
+  if (!apiToken) {
+    console.log('No GROC_API_TOKEN set; relying on localhost binding for access control.');
+  }
+  if (host !== '127.0.0.1' && host !== 'localhost' && !apiToken) {
+    console.warn('WARNING: API is not bound to localhost and has no token. Set GROC_API_TOKEN.');
+  }
+});


### PR DESCRIPTION
NanoClaw (for example) has network access but no filesystem access to call the `groc` CLI. This PR adds a little API so it can call groc over the network.

NB:
- I don't particularly expect you to merge this.
- I added a skill and simple script for using the endpoint, not very sure those should go in the repo but I'm using them so added them.
- This includes the favourites stuff from #9, so that should be merged before this.