### PR TITLE
fix(sainsburys): replace guessed order endpoints with verified working API

### DIFF
--- a/skills/sainsburys.md
+++ b/skills/sainsburys.md
@@ -110,13 +110,17 @@ When using the MCP server, these tools are available with `provider: "sainsburys
 ```
 Base: https://www.sainsburys.co.uk/groceries-api/gol-services
 
-GET  /product/v1/product?filter[keyword]=milk    # Search
-GET  /basket/v2/basket                            # View basket
-POST /basket/v2/basket/items                      # Add to basket
-PUT  /basket/v2/basket                            # Update basket
-GET  /slot/v1/slot/reservation                    # Delivery slots
-POST /checkout/v1/checkout                        # Checkout
+GET  /product/v1/product?filter[keyword]=milk         # Search
+GET  /basket/v2/basket                                 # View basket
+POST /basket/v2/basket/items                           # Add to basket
+PUT  /basket/v2/basket                                 # Update basket
+GET  /slot/v1/slot/reservation                         # Delivery slots
+POST /checkout/v1/checkout                             # Checkout
+GET  /order/v1/order?page_size=10&page_number=1        # Order history list
+GET  /order/v1/order/{order_uid}                       # Single order detail (incl. items)
 ```
+
+**Order history note:** The correct page URL is `/gol-ui/my-account/orders`, not `/shop/gb/groceries/order-history` (which is a legacy 404). The API returns `order_uid` (not `order_id`) and `order_items` (not `items`) in the detail response.
 
 ---
 

--- a/src/providers/sainsburys.ts
+++ b/src/providers/sainsburys.ts
@@ -258,43 +258,48 @@ export class SainsburysProvider implements GroceryProvider {
   }
 
   async getOrders(): Promise<Order[]> {
-    try {
-      // Try common order history endpoints
-      const endpoints = [
-        '/order/v1/orders',
-        '/order/v1/history', 
-        '/orders/v1/history',
-        '/customer/v1/orders'
-      ];
-      
-      for (const endpoint of endpoints) {
+    // Fetch the order list
+    const listResponse = await this.client.get('/order/v1/order', {
+      params: { page_size: 10, page_number: 1 }
+    });
+
+    const rawOrders: any[] = listResponse.data.orders || [];
+
+    // Fetch full detail for each order (needed to get order_items)
+    const orders = await Promise.all(
+      rawOrders.map(async (o: any) => {
+        let items: BasketItem[] = [];
         try {
-          const response = await this.client.get(endpoint);
-          if (response.data && (response.data.orders || response.data.order_history)) {
-            const orders = response.data.orders || response.data.order_history || [];
-            return orders.map((o: any) => ({
-              order_id: o.order_id || o.order_number || o.id,
-              status: o.status || o.order_status || 'unknown',
-              total: parseFloat(o.total || o.total_cost || o.order_total || 0),
-              delivery_slot: o.delivery_slot ? {
-                slot_id: o.delivery_slot.slot_id || '',
-                start_time: o.delivery_slot.start_time || '',
-                end_time: o.delivery_slot.end_time || '',
-                date: o.delivery_slot.date || '',
-                price: parseFloat(o.delivery_slot.price || 0),
-                available: true
-              } : undefined,
-              items: o.items || []
-            }));
-          }
-        } catch (e) {
-          continue;
+          const detail = await this.client.get(`/order/v1/order/${o.order_uid}`);
+          items = (detail.data.order_items || []).map((item: any) => ({
+            item_id: item.product.product_uid,
+            product_uid: item.product.product_uid,
+            name: item.product.name,
+            quantity: item.quantity,
+            unit_price: parseFloat((item.sub_total / item.quantity).toFixed(2)),
+            total_price: parseFloat(item.sub_total)
+          }));
+        } catch {
+          // detail fetch failed — order still usable without items
         }
-      }
-      
-      return [];
-    } catch (error: any) {
-      return [];
-    }
+
+        return {
+          order_id: o.order_uid,
+          status: o.status,
+          total: parseFloat(o.total || 0),
+          delivery_slot: o.slot_start_time ? {
+            slot_id: '',
+            start_time: o.slot_start_time,
+            end_time: o.slot_end_time || '',
+            date: o.slot_start_time.split('T')[0],
+            price: parseFloat(o.slot_price || 0),
+            available: true
+          } : undefined,
+          items
+        };
+      })
+    );
+
+    return orders;
   }
 }


### PR DESCRIPTION
## Problem

`getOrders()` tried four guessed API paths in a loop — all of them return 404 or empty data on a real authenticated Sainsbury's account, so order history has never worked.

## Fix

Replaced the guessing strategy with the **actual endpoints**, discovered by intercepting network traffic on the authenticated `/gol-ui/my-account/orders` page:

| Endpoint | Purpose |
|---|---|
| `GET /order/v1/order?page_size=10&page_number=1` | Paginated order list |
| `GET /order/v1/order/{order_uid}` | Full order detail including line items |

### Key field corrections

| Old (guessed) | Actual |
|---|---|
| `order_id` / `order_number` | `order_uid` |
| `items` array in list response | `order_items` array in detail response |
| `delivery_slot.date` object | `slot_start_time` / `slot_end_time` ISO strings |

The fix fetches the order list then resolves each order's detail in parallel (via `Promise.all`) to populate the `items` array, matching the `Order` interface.

## Also updated

`skills/sainsburys.md` — documents the correct API endpoints and notes that `/gol-ui/my-account/orders` is the right page URL (the old `/shop/gb/groceries/order-history` redirects to a 404).

## Tested

Verified against a live authenticated UK Sainsbury's account. Returns full order history with item-level detail (product name, uid, quantity, subtotal) for all recent orders.

---
*Found while building a frequently-bought-items analyser on top of this tool.*