### PR TITLE
Improve Tesco auth resilience and published CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Built for agent frameworks like [OpenClaw](https://github.com/claw-labs/openclaw
 
 ## Supported Supermarkets
 
-- ✅ **Sainsbury's** - UK-wide delivery, full API coverage
+- ✅ **Sainsbury's** - UK-wide delivery, search + basket flow
 - ⚠️ **Ocado** - **Currently broken.** Ocado migrated to a client-side React SPA and the previous endpoints have been removed. Provider is disabled and will throw a clear error until rebuilt. Tracking: [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5)
-- ✅ **Tesco** - UK-wide delivery, full API coverage (search, basket, checkout)
+- ✅ **Tesco** - UK-wide delivery, search + basket + slots; browser-cookie import recommended for auth
 - 🔜 **Asda** - Planned Q2 2026
 - 🔜 **Morrisons** - Planned Q2 2026
 
@@ -307,6 +307,7 @@ groc checkout            Place order
 ### Tesco-Specific Commands
 
 ```bash
+groc --provider tesco status                                  Check saved Tesco session/auth state
 groc --provider tesco import-session --file <cookies.json>   Import cookies from browser export
 groc --provider tesco staples                                 Analyse order history → repeat-buy suggestions
 groc --provider tesco discover                                Network interception tool for API discovery (dev)
@@ -325,9 +326,9 @@ groc status              Check login status
 
 ### Tesco Authentication
 
-Tesco uses Akamai bot detection, which can block automated form filling. Three options:
+Tesco uses Akamai bot detection, which can block automated form filling. The CLI now launches Playwright with stealth patches and a real Chrome channel when available, but imported browser cookies remain the reliable path.
 
-**Option 1 — Automated login (may be blocked):**
+**Option 1 — Automated login (improved, still may be blocked):**
 ```bash
 npm run groc -- --provider tesco login --email EMAIL --password PASS
 # Omit --password to be prompted interactively (keeps password out of shell history)
@@ -347,7 +348,7 @@ npm run groc -- --provider tesco import-session --file ~/Downloads/tesco-cookies
 TESCO_PASSWORD=yourpass npm run groc -- --provider tesco login --email EMAIL
 ```
 
-Session is saved to `~/.tesco/session.json` and lasts ~7 days.
+Session is saved to `~/.tesco/session.json`. Tesco controls the real lifetime; run `groc --provider tesco status` if basket calls start returning 401/403.
 
 ## Payment & Security
 
@@ -467,13 +468,14 @@ uk-grocery-cli/
 ## Known Limitations
 
 ### Authentication
-- **Sainsbury's**: SMS 2FA required on every fresh login — session lasts ~7 days
-- **Tesco**: Akamai bot detection can block automated login. Use `import-session` (manual browser login → Cookie Editor export → `groc --provider tesco import-session --file cookies.json`) as the reliable path. Session lasts ~7 days.
+- **Sainsbury's**: SMS 2FA required on every fresh login — session duration is controlled by Sainsbury's
+- **Tesco**: Akamai bot detection can block automated login. Use `import-session` (manual browser login → Cookie Editor export → `groc --provider tesco import-session --file cookies.json`) as the reliable path. Session duration is controlled by Tesco and may be short.
 - **Ocado**: ⚠️ Disabled. Site moved to React SPA, previous endpoints removed. See [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5).
 
 ### API Coverage
-- ✅ **Working**: Search, basket management, product data — Sainsbury's and Tesco
-- ✅ **Working**: Tesco delivery slots + checkout (browser-automated, requires manual payment confirmation)
+- ✅ **Working**: Sainsbury's and Tesco search/product data; Tesco basket/slots with a valid session
+- ⚠️ **Partial**: Basket management depends on supermarket session lifetime and bot checks
+- ✅ **Working**: Tesco delivery slots + checkout handoff (browser-automated, requires manual payment confirmation)
 - ⚠️ **Experimental**: Sainsbury's checkout flow (needs real-world testing)
 - ⚠️ **Broken**: Entire Ocado provider — endpoints removed by Ocado, awaiting rebuild ([#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5))
 - 🔜 **Coming**: Order tracking, substitutions, favourites
@@ -507,9 +509,9 @@ Open an issue or PR.
 
 ### v2.0 (Current)
 - ✅ Multi-provider architecture
-- ✅ Sainsbury's provider (full coverage)
+- ✅ Sainsbury's provider (search + basket flow)
 - ⚠️ Ocado provider (disabled — see [#5](https://github.com/abracadabra50/uk-grocery-cli/issues/5))
-- ✅ Tesco provider (full coverage — search, basket, checkout, slots, staples)
+- ✅ Tesco provider (search, basket, checkout handoff, slots, staples; cookie import recommended)
 
 ### v2.1 (Current)
 - ✅ Full MCP server with multi-provider support

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "axios": "^1.6.0",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
-        "playwright": "^1.40.0"
+        "playwright": "^1.40.0",
+        "playwright-extra": "^4.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2"
       },
       "bin": {
         "groc": "dist/cli.js",
@@ -482,9 +484,10 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
       },
@@ -587,6 +590,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
@@ -658,6 +676,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -711,6 +741,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -718,15 +757,22 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -749,6 +795,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bytes": {
@@ -803,6 +859,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -841,6 +913,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -928,6 +1006,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -1146,11 +1233,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1191,9 +1279,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1203,7 +1291,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1226,9 +1315,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -1243,6 +1332,27 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/form-data": {
@@ -1276,6 +1386,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1350,6 +1480,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1361,6 +1512,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1411,9 +1568,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1437,6 +1595,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1452,15 +1623,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -1473,6 +1656,33 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1482,6 +1692,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -1500,6 +1719,39 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1523,6 +1775,20 @@
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -1555,6 +1821,40 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ms": {
@@ -1616,6 +1916,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1625,9 +1934,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -1671,6 +1981,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright-extra": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
+      "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "playwright-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1684,10 +2018,119 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
+      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-stealth": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
+      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
+      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
+      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -1741,6 +2184,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/router": {
@@ -1833,6 +2292,42 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2084,6 +2579,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uk-grocery-cli",
   "version": "2.1.0",
   "description": "Multi-supermarket grocery CLI for UK. Sainsbury's, Ocado, and more. Built for AI agents.",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/cli.js",
   "bin": {
     "groc": "./dist/cli.js",
@@ -40,7 +40,9 @@
     "axios": "^1.6.0",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
-    "playwright": "^1.40.0"
+    "playwright": "^1.40.0",
+    "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,53 @@ program
     }
   });
 
+// Status
+program
+  .command('status')
+  .description('Check saved session/authentication status')
+  .option('--json', 'Output as JSON')
+  .action(async (options, cmd) => {
+    try {
+      const providerName = cmd.optsWithGlobals().provider;
+      const provider = getProvider(cmd.optsWithGlobals());
+      const sessionInfo = providerName === 'tesco'
+        ? (await import('./providers/tesco/auth')).getSessionInfo()
+        : undefined;
+      const authenticated = await provider.isAuthenticated();
+
+      const result = {
+        provider: provider.name,
+        authenticated,
+        session: sessionInfo,
+      };
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`\n🔐 ${provider.name.toUpperCase()} Status\n`);
+      console.log(`Authenticated: ${authenticated ? '✅ yes' : '❌ no'}`);
+
+      if (sessionInfo) {
+        console.log(`Session file: ${sessionInfo.exists ? sessionInfo.path : 'not found'}`);
+        if (sessionInfo.exists) {
+          console.log(`Cookies: ${sessionInfo.cookieCount}`);
+          console.log(`Last login/import: ${sessionInfo.lastLogin || 'unknown'}`);
+          console.log(`Expires: ${sessionInfo.expiresAt || 'unknown'} ${sessionInfo.expired ? '(expired)' : ''}`);
+        }
+      }
+
+      if (!authenticated) {
+        console.log('\n💡 Refresh with `groc login` or import browser cookies with `groc --provider tesco import-session --file <cookies.json>`.');
+      }
+      console.log();
+    } catch (error: any) {
+      console.error('❌ Status check failed:', error.message);
+      process.exit(1);
+    }
+  });
+
 // Search
 program
   .command('search <query>')

--- a/src/providers/tesco/api.ts
+++ b/src/providers/tesco/api.ts
@@ -23,6 +23,20 @@ const ORDERS_URL = 'https://www.tesco.com/groceries/en-GB/orders';
 // Static API key baked into Tesco's mfe-* bundles (confirmed from discovery)
 const TESCO_API_KEY = 'TvOSZJHlEk0pjniDGQFAc9Q59WGAR4dA';
 
+function isAuthError(error: any): boolean {
+  const status = error?.response?.status;
+  return status === 401 || status === 403;
+}
+
+function tescoSessionHelp(status?: number): string {
+  return [
+    `Tesco session rejected${status ? ` (${status})` : ''}.`,
+    'Run `groc --provider tesco status` to check the saved session.',
+    'If it has expired, log in again or import fresh browser cookies:',
+    '`groc --provider tesco import-session --file ~/Downloads/tesco-cookies.json`',
+  ].join(' ');
+}
+
 export class TescoAPI {
   private client: AxiosInstance;
 
@@ -41,6 +55,16 @@ export class TescoAPI {
       },
       withCredentials: true,
     });
+
+    this.client.interceptors.response.use(
+      response => response,
+      error => {
+        if (isAuthError(error)) {
+          error.message = tescoSessionHelp(error.response?.status);
+        }
+        return Promise.reject(error);
+      }
+    );
   }
 
   /** Inject session cookies from ~/.tesco/session.json */

--- a/src/providers/tesco/auth.ts
+++ b/src/providers/tesco/auth.ts
@@ -3,24 +3,40 @@
  *
  * Interactive browser-based login via Playwright.
  * Tesco uses email OTP (not SMS) for MFA, and Akamai bot-detection,
- * so we launch a real non-headless browser with anti-bot flags.
+ * so we launch a real non-headless browser with stealth patches.
  *
  * Session stored at ~/.tesco/session.json (same shape as Sainsbury's).
  */
 
-import { chromium } from 'playwright';
+import { chromium } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import type { Browser, LaunchOptions, Page } from 'playwright';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
 
+chromium.use(StealthPlugin());
+
 const CONFIG_DIR = path.join(os.homedir(), '.tesco');
 const SESSION_FILE = path.join(CONFIG_DIR, 'session.json');
+const DEFAULT_SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+
+const AUTH_COOKIE_RE = /(auth|oauth|token|session|sid|sso|identity|access|refresh|jwt|tesco)/i;
 
 export interface TescoSession {
   cookies: any[];
   expiresAt: string;
   lastLogin: string;
+}
+
+export interface TescoSessionInfo {
+  exists: boolean;
+  path: string;
+  expired: boolean;
+  expiresAt?: string;
+  lastLogin?: string;
+  cookieCount?: number;
 }
 
 function ask(question: string): Promise<string> {
@@ -56,23 +72,85 @@ function askHidden(question: string): Promise<string> {
   });
 }
 
-export async function login(email: string, password?: string): Promise<TescoSession> {
-  const pwd = password || process.env.TESCO_PASSWORD || await askHidden('Password: ');
-  console.log('🔐 Logging in to Tesco...');
+function cookieExpiryMs(cookie: any): number | null {
+  const raw = cookie?.expires ?? cookie?.expirationDate ?? cookie?.ExpirationDate;
+  if (raw === undefined || raw === null || raw === -1 || raw === 0) return null;
 
-  const browser = await chromium.launch({
+  const numeric = Number(raw);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+
+  // Playwright and Chrome exports use seconds; tolerate millisecond exports too.
+  return numeric > 10_000_000_000 ? numeric : numeric * 1000;
+}
+
+export function inferSessionExpiry(cookies: any[], fallbackMs: number = DEFAULT_SESSION_TTL_MS): string {
+  const now = Date.now();
+  const authCookieExpiries = cookies
+    .filter(cookie => AUTH_COOKIE_RE.test(String(cookie?.name || '')))
+    .map(cookieExpiryMs)
+    .filter((expiry): expiry is number => !!expiry && expiry > now + 60_000)
+    .sort((a, b) => a - b);
+
+  if (authCookieExpiries.length > 0) {
+    return new Date(authCookieExpiries[0]).toISOString();
+  }
+
+  return new Date(now + fallbackMs).toISOString();
+}
+
+async function launchTescoBrowser(): Promise<Browser> {
+  const launchOptions: LaunchOptions = {
     headless: false,
     args: [
       '--disable-blink-features=AutomationControlled',
       '--disable-features=IsolateOrigins,site-per-process',
+      '--no-default-browser-check',
+      '--disable-dev-shm-usage',
     ],
-  });
+  };
+
+  const preferredChannel = process.env.GROC_BROWSER_CHANNEL || process.env.PLAYWRIGHT_CHROMIUM_CHANNEL || 'chrome';
+
+  try {
+    return await chromium.launch({ ...launchOptions, channel: preferredChannel });
+  } catch (error: any) {
+    if (preferredChannel) {
+      console.log(`⚠️  Could not launch ${preferredChannel}; falling back to bundled Chromium.`);
+    }
+    return chromium.launch(launchOptions);
+  }
+}
+
+async function isTescoSecurityBlock(page: Page): Promise<boolean> {
+  const body = await page.locator('body').innerText({ timeout: 3000 }).catch(() => '');
+  return /failed some security checks|something is not right|access denied|unusual traffic/i.test(body);
+}
+
+function blockedLoginMessage(): string {
+  return [
+    'Tesco blocked the automated browser with its security checks.',
+    'Reliable fallback:',
+    '1. Log in to https://www.tesco.com/groceries/en-GB/ in your normal browser',
+    '2. Export Tesco cookies with Cookie-Editor or DevTools',
+    '3. Run: groc --provider tesco import-session --file ~/Downloads/tesco-cookies.json',
+  ].join('\n');
+}
+
+export async function login(email: string, password?: string): Promise<TescoSession> {
+  const pwd = password || process.env.TESCO_PASSWORD || await askHidden('Password: ');
+  console.log('🔐 Logging in to Tesco...');
+
+  const browser = await launchTescoBrowser();
 
   const context = await browser.newContext({
     userAgent:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
     viewport: { width: 1440, height: 900 },
+    locale: 'en-GB',
+    timezoneId: 'Europe/London',
   });
+
+  await context.addInitScript("Object.defineProperty(navigator, 'webdriver', { get: () => undefined });");
 
   const page = await context.newPage();
 
@@ -82,6 +160,10 @@ export async function login(email: string, password?: string): Promise<TescoSess
       'https://www.tesco.com/account/auth/en-GB/login?from=https%3A%2F%2Fwww.tesco.com%2Fgroceries%2Fen-GB%2F',
       { waitUntil: 'domcontentloaded', timeout: 30000 }
     );
+
+    if (await isTescoSecurityBlock(page)) {
+      throw new Error(blockedLoginMessage());
+    }
 
     // Accept cookies
     try {
@@ -107,6 +189,10 @@ export async function login(email: string, password?: string): Promise<TescoSess
       await page.waitForTimeout(1500);
     }
 
+    if (await isTescoSecurityBlock(page)) {
+      throw new Error(blockedLoginMessage());
+    }
+
     // Password field — long timeout so user can solve Akamai/CAPTCHA challenges manually
     console.log('🔑 Waiting for password field... (solve any challenges in the browser window)');
     try {
@@ -120,9 +206,13 @@ export async function login(email: string, password?: string): Promise<TescoSess
       await page.waitForTimeout(5000);
     } catch {
       // Password field never appeared — Akamai bot detection likely triggered
-      console.log('\n⚠️  Automated form fill timed out (Akamai may be showing a challenge).');
+      console.log('\n⚠️  Automated form fill timed out.');
       console.log('   Please complete the login in the browser window, then press Enter here.');
       await ask('Press Enter once logged in: ');
+    }
+
+    if (await isTescoSecurityBlock(page)) {
+      throw new Error(blockedLoginMessage());
     }
 
     const currentUrl = page.url();
@@ -148,7 +238,7 @@ export async function login(email: string, password?: string): Promise<TescoSess
         await page.click('button[type="submit"]');
       } else {
         // "Is this you?" notification — session cookies are already set, just navigate away
-        console.log('\n📧 Tesco sent a "is this you?" notification — session already established.');
+        console.log('\n📧 Tesco sent a "is this you?" notification — session may already be established.');
         console.log('   Navigating to groceries...\n');
         await page.goto('https://www.tesco.com/groceries/en-GB/', {
           waitUntil: 'domcontentloaded',
@@ -166,7 +256,7 @@ export async function login(email: string, password?: string): Promise<TescoSess
     const cookies = await context.cookies();
     const session: TescoSession = {
       cookies,
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      expiresAt: inferSessionExpiry(cookies),
       lastLogin: new Date().toISOString(),
     };
 
@@ -184,8 +274,26 @@ export function saveSession(session: TescoSession): void {
   if (!fs.existsSync(CONFIG_DIR)) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
   }
-  fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+  fs.writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2), { mode: 0o600 });
   console.log(`💾 Tesco session saved to ${SESSION_FILE}`);
+}
+
+export function getSessionInfo(): TescoSessionInfo {
+  if (!fs.existsSync(SESSION_FILE)) {
+    return { exists: false, path: SESSION_FILE, expired: true };
+  }
+
+  const session: TescoSession = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
+  const expired = new Date(session.expiresAt) < new Date();
+
+  return {
+    exists: true,
+    path: SESSION_FILE,
+    expired,
+    expiresAt: session.expiresAt,
+    lastLogin: session.lastLogin,
+    cookieCount: session.cookies?.length || 0,
+  };
 }
 
 export function loadSession(): TescoSession | null {
@@ -194,7 +302,7 @@ export function loadSession(): TescoSession | null {
   const session: TescoSession = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
 
   if (new Date(session.expiresAt) < new Date()) {
-    console.log('⚠️  Tesco session expired — please login again');
+    console.log('⚠️  Tesco session expired — please login again or import a fresh browser session');
     return null;
   }
 

--- a/src/providers/tesco/import-session.ts
+++ b/src/providers/tesco/import-session.ts
@@ -19,7 +19,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { saveSession, TescoSession } from './auth';
+import { inferSessionExpiry, saveSession, TescoSession } from './auth';
 
 export function importSession(filePath: string): void {
   const resolved = filePath.startsWith('~')
@@ -61,12 +61,18 @@ export function importSession(filePath: string): void {
     sameSite: c.sameSite || c.SameSite || 'Lax',
   }));
 
+  const validCookies = normalised.filter((c: any) => c.name && c.value);
+
+  if (validCookies.length === 0) {
+    throw new Error('No usable cookies found in the file. Check the export includes name/value fields.');
+  }
+
   const session: TescoSession = {
-    cookies: normalised,
-    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    cookies: validCookies,
+    expiresAt: inferSessionExpiry(validCookies),
     lastLogin: new Date().toISOString(),
   };
 
   saveSession(session);
-  console.log(`✅ Imported ${normalised.length} cookies — Tesco session ready`);
+  console.log(`✅ Imported ${validCookies.length} cookies — Tesco session ready until ${session.expiresAt}`);
 }

--- a/src/providers/tesco/index.ts
+++ b/src/providers/tesco/index.ts
@@ -8,11 +8,6 @@
 import { GroceryProvider, Product, Basket, DeliverySlot, Order, SearchOptions, BasketItem } from '../types';
 import { TescoAPI } from './api';
 import { login, loadSession, clearSession, getCookieString } from './auth';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-
-const SESSION_FILE = path.join(os.homedir(), '.tesco', 'session.json');
 
 export class TescoProvider implements GroceryProvider {
   readonly name = 'tesco';
@@ -25,14 +20,9 @@ export class TescoProvider implements GroceryProvider {
 
   private loadSession(): void {
     try {
-      if (fs.existsSync(SESSION_FILE)) {
-        const session = JSON.parse(fs.readFileSync(SESSION_FILE, 'utf-8'));
-        if (session.cookies && Array.isArray(session.cookies)) {
-          const cookieString = session.cookies
-            .map((c: any) => `${c.name}=${c.value}`)
-            .join('; ');
-          this.api.setAuthCookies(cookieString);
-        }
+      const session = loadSession();
+      if (session?.cookies && Array.isArray(session.cookies)) {
+        this.api.setAuthCookies(getCookieString(session));
       }
     } catch {
       // Ignore session load errors silently

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "lib": ["ES2020"],
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
- add stealth-patched Tesco Playwright login using a real Chrome channel when available
- add `groc status` and Tesco session metadata so short-lived cookies are obvious instead of mysterious 401s
- improve Tesco 401/403 guidance and cookie import expiry handling
- switch build output to CommonJS so the published `groc` bin works under Node without ESM directory import failures
- update README support claims for Tesco/Ocado reality
- run `npm audit fix` so production audit is clean

## Testing
- `npm run build`
- `node dist/cli.js --provider tesco search milk --limit 2 --json`
- `node dist/cli.js --provider tesco status --json`
- temp-home `node dist/cli.js --provider tesco import-session --file <cookies.json>`
- `node dist/cli.js providers`
- `node dist/mcp-server.js` startup/import smoke
- `npm audit --omit=dev`
- `npm pack --dry-run`

## Context
Addresses the public Tesco auth/session pain from #8 and #11, and the global install/module-resolution problem raised in #7.
