### PR TITLE
fix(tesco): match slot availability case-insensitively

### DIFF
--- a/src/providers/tesco/index.ts
+++ b/src/providers/tesco/index.ts
@@ -145,7 +145,7 @@ export class TescoProvider implements GroceryProvider {
         end_time: s.end ? new Date(s.end).toTimeString().slice(0, 5) : '',
         date: s.start ? new Date(s.start).toISOString().slice(0, 10) : '',
         price: parseFloat(s.price?.afterDiscount || s.charge || 0),
-        available: s.status === 'available' || s.status === 'AVAILABLE',
+        available: String(s.status || '').toLowerCase() === 'available',
       }));
 
     } catch {


### PR DESCRIPTION
## Summary
- Tesco's GraphQL `delivery.status` field comes back as title-case strings (`"Available"` / `"Unavailable"`), but the slot mapper in `src/providers/tesco/index.ts` only matched `"available"` or `"AVAILABLE"`.
- Result: every Tesco slot was reported as `available: false`, so `groc --provider tesco slots` showed every slot as ❌ even when most were bookable.
- Fix: compare case-insensitively (`String(s.status || '').toLowerCase() === 'available'`).

## Reproduction (before this fix)
```
$ groc --provider tesco slots --json | jq '[.slots[] | select(.available)] | length'
0   # …out of 240 returned across 15 days
```
With debug logging added to the mapper, the raw API returned `{ Available: 168, Unavailable: 72 }` — i.e. 70% of slots were genuinely bookable but every one was being flipped to false.

After the fix, `groc --provider tesco slots` correctly shows available slots with ✅.

## Test plan
- [x] Rebuild (`npm run build`) and re-run `groc --provider tesco slots --json`; confirm a realistic mix of available/unavailable slots.
- [ ] Maintainer sanity check on a different Tesco account to confirm the title-case status string is consistent across regions/accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)