### PR TITLE
fix(tesco): real order history + correct basket item-ID resolution

### DIFF
--- a/src/providers/tesco/api.ts
+++ b/src/providers/tesco/api.ts
@@ -352,9 +352,6 @@ export class TescoAPI {
             status
             createdDateTime
             totalPrice
-            totalItems
-            paymentMode
-            shoppingMethod
             slot { start end charge }
             items {
               quantity
@@ -363,7 +360,6 @@ export class TescoAPI {
               product { id title }
             }
           }
-          info { total page count pageSize offset }
         }
       }
     `, {

--- a/src/providers/tesco/api.ts
+++ b/src/providers/tesco/api.ts
@@ -394,7 +394,12 @@ export class TescoAPI {
             items {
               actual {
                 items {
-                  product { title }
+                  product {
+                    title
+                    tpnb
+                    tpnc
+                    price { beforeDiscount afterDiscount unitPrice }
+                  }
                   quantity { numberOfUnits weight unitOfMeasure }
                 }
               }

--- a/src/providers/tesco/api.ts
+++ b/src/providers/tesco/api.ts
@@ -357,7 +357,7 @@ export class TescoAPI {
               quantity
               unit
               weight
-              product { id title }
+              product { id tpnb tpnc title }
             }
           }
         }
@@ -384,21 +384,12 @@ export class TescoAPI {
           createdDateTime
           totalPrice
           slot { start end charge }
-          fulfilment {
-            status
-            totalItems
+          splitView {
             items {
-              actual {
-                items {
-                  product {
-                    title
-                    tpnb
-                    tpnc
-                    price { beforeDiscount afterDiscount unitPrice }
-                  }
-                  quantity { numberOfUnits weight unitOfMeasure }
-                }
-              }
+              id
+              cost
+              quantity
+              product { title tpnb tpnc }
             }
           }
         }

--- a/src/providers/tesco/api.ts
+++ b/src/providers/tesco/api.ts
@@ -18,7 +18,6 @@
 import axios, { AxiosInstance } from 'axios';
 
 const XAPI_URL = 'https://xapi.tesco.com/';
-const ORDERS_URL = 'https://www.tesco.com/groceries/en-GB/orders';
 
 // Static API key baked into Tesco's mfe-* bundles (confirmed from discovery)
 const TESCO_API_KEY = 'TvOSZJHlEk0pjniDGQFAc9Q59WGAR4dA';
@@ -340,25 +339,70 @@ export class TescoAPI {
   }
 
   // ─────────────────────────────────────────────────────────
-  // Orders (REST endpoint, not GraphQL)
+  // Orders (GraphQL — mfe-orders, discovered from live traffic 2026-08-08)
   // ─────────────────────────────────────────────────────────
 
   async getOrders(page: number = 1, pageSize: number = 10) {
-    try {
-      const response = await this.client.get(ORDERS_URL, {
-        params: { page, pageSize },
-        headers: { Accept: 'application/json' },
-      });
-      return response.data;
-    } catch {
-      return null;
-    }
+    const data = await this.gql('GetPreviousOrdersWithPagination', `
+      query GetPreviousOrdersWithPagination($orderContexts: [OrderContextType], $page: Int, $count: Int) {
+        orderSearch(page: $page, count: $count, orderContexts: $orderContexts) {
+          orders {
+            id
+            orderNo
+            status
+            createdDateTime
+            totalPrice
+            totalItems
+            paymentMode
+            shoppingMethod
+            slot { start end charge }
+            items {
+              quantity
+              unit
+              weight
+              product { id title }
+            }
+          }
+          info { total page count pageSize offset }
+        }
+      }
+    `, {
+      orderContexts: [
+        { type: 'GROCERY', statuses: ['Previous'] },
+        { type: 'MARKETPLACE', statuses: ['Previous'] },
+        { type: 'FNF', statuses: ['Previous'] },
+      ],
+      page,
+      count: pageSize,
+    });
+    return data?.orderSearch;
   }
 
   async getOrder(orderId: string) {
-    const response = await this.client.get(`${ORDERS_URL}/${orderId}`, {
-      headers: { Accept: 'application/json' },
-    });
-    return response.data;
+    const data = await this.gql('GetOrderReceipt', `
+      query GetOrderReceipt($id: ID!) {
+        order(orderId: $id) {
+          id
+          orderNo
+          status
+          createdDateTime
+          totalPrice
+          slot { start end charge }
+          fulfilment {
+            status
+            totalItems
+            items {
+              actual {
+                items {
+                  product { title }
+                  quantity { numberOfUnits weight unitOfMeasure }
+                }
+              }
+            }
+          }
+        }
+      }
+    `, { id: orderId });
+    return data?.order;
   }
 }

--- a/src/providers/tesco/index.ts
+++ b/src/providers/tesco/index.ts
@@ -99,21 +99,36 @@ export class TescoProvider implements GroceryProvider {
     return orderId;
   }
 
+  /**
+   * UpdateBasket takes product_uid (TPNC), but the CLI's `remove`/`update` commands
+   * are documented to take the basket item_id (the barcode-style ID shown by `groc
+   * basket`) — matching every other provider. Resolve whichever one we were given
+   * against the live basket so both forms work.
+   */
+  private async resolveProductUid(itemOrProductId: string): Promise<string> {
+    const basket = await this.getBasket();
+    const match = basket.items.find(
+      i => i.item_id === itemOrProductId || i.product_uid === itemOrProductId
+    );
+    return match?.product_uid || itemOrProductId;
+  }
+
   async addToBasket(productId: string, quantity: number): Promise<void> {
     const orderId = await this.getBasketOrderId();
     await this.api.updateBasket(productId, quantity, orderId);
   }
 
   async updateBasketItem(itemId: string, quantity: number): Promise<void> {
-    // itemId here is the product_uid (TPNC) since that's what UpdateBasket takes
+    const productUid = await this.resolveProductUid(itemId);
     const orderId = await this.getBasketOrderId();
-    await this.api.updateBasket(itemId, quantity, orderId);
+    await this.api.updateBasket(productUid, quantity, orderId);
   }
 
   async removeFromBasket(itemId: string): Promise<void> {
+    const productUid = await this.resolveProductUid(itemId);
     // Set quantity to 0 to remove
     const orderId = await this.getBasketOrderId();
-    await this.api.updateBasket(itemId, 0, orderId);
+    await this.api.updateBasket(productUid, 0, orderId);
   }
 
   async clearBasket(): Promise<void> {
@@ -190,27 +205,30 @@ export class TescoProvider implements GroceryProvider {
 
   async getOrders(): Promise<Order[]> {
     const data = await this.api.getOrders();
-    if (!data) return [];
-
-    const rawOrders: any[] = Array.isArray(data)
-      ? data
-      : (data.orders || data.orderHistory || []);
+    const rawOrders: any[] = data?.orders || [];
 
     return rawOrders.map((o: any) => ({
-      order_id: String(o.id || o.orderId || o.order_id || ''),
-      status: o.status || o.orderStatus || 'unknown',
-      total: parseFloat(o.total || o.orderTotal || o.totalAmount || 0),
-      delivery_slot: o.deliverySlot
+      order_id: String(o.orderNo || o.id || ''),
+      status: o.status || 'unknown',
+      total: parseFloat(o.totalPrice || 0),
+      delivery_slot: o.slot
         ? {
-            slot_id: String(o.deliverySlot.id || o.deliverySlot.slotId || ''),
-            start_time: o.deliverySlot.startTime || o.deliverySlot.start || '',
-            end_time: o.deliverySlot.endTime || o.deliverySlot.end || '',
-            date: o.deliverySlot.date || '',
-            price: parseFloat(o.deliverySlot.price || 0),
+            slot_id: '',
+            start_time: o.slot.start || '',
+            end_time: o.slot.end || '',
+            date: o.createdDateTime || '',
+            price: parseFloat(o.slot.charge || 0),
             available: true,
           }
         : undefined,
-      items: (o.items || o.orderLines || []).map((i: any) => this.normaliseBasketItem(i)),
+      items: (o.items || []).map((i: any) => ({
+        item_id: '',
+        product_uid: String(i.product?.id || ''),
+        name: i.product?.title || '',
+        quantity: i.quantity || 0,
+        unit_price: 0,
+        total_price: 0,
+      })),
     }));
   }
 


### PR DESCRIPTION
`groc --provider tesco orders` returned no data before this fix. The command called a webpage URL, not an API endpoint. This fix makes the command return real order history.

`groc --provider tesco remove` and `groc --provider tesco update` did not change the basket before this fix. The commands used the wrong item identifier. This fix makes both commands change the basket.

## How it works

- The `getOrders` function now calls the `GetPreviousOrdersWithPagination` GraphQL query. This query returns real order data from `xapi.tesco.com`. The query was found through a network capture of the live orders page.
- The `getOrder` function now calls the `GetOrderReceipt` GraphQL query. This query returns the items and the price paid for each order.
- The `removeFromBasket` and `updateBasketItem` functions now accept either the basket item ID or the product ID. The functions look up the correct product ID in the current basket before they change it.

## Along the way

- The order-list query no longer requests unused fields. The `paymentMode`, `shoppingMethod`, and pagination fields did not appear in the CLI output.
- The order-list query now requests `tpnb` and `tpnc` for each product. These fields let other tools match the same product across different orders.
- The `GetOrderReceipt` query now requests the price paid for each item. The earlier query returned today's catalogue price, not the price paid at checkout. This made every historical order look far more expensive than it was.

## Test plan

- [x] Type check passes: `npx tsc --noEmit`.
- [x] `groc --provider tesco orders --limit 5` returns real order data. Verified against a live account with ten orders.
- [x] `groc --provider tesco update <item_id> <qty>` changes the basket quantity. Verified against a live basket.
- [x] `groc --provider tesco remove <item_id>` removes the item from the basket. Verified against a live basket.
- [x] Item price now matches the amount paid at checkout. Verified against a live account: order totals now match summed item costs on several orders.
