### PR TITLE
Expose the barcode Tesco and Sainsbury's already return

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "setup": "./setup.sh",
     "supermarket": "tsx src/cli.ts",
     "prepublishOnly": "npm run build",
-    "test": "tsx test/lazy-loading.test.ts",
+    "test": "tsx test/lazy-loading.test.ts && tsx test/gtin.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/src/providers/gtin.ts
+++ b/src/providers/gtin.ts
@@ -1,0 +1,48 @@
+/**
+ * GTIN normalisation, so two providers' barcodes are comparable.
+ *
+ * Tesco and Sainsbury's both return a real barcode for the same product, in
+ * different shapes: Tesco zero-pads to 14 (`05000157024671`), Sainsbury's
+ * returns a bare EAN-13 (`5000157026071`). Compared as strings those never
+ * match, which is the whole reason a caller cannot currently line up a branded
+ * product across two retailers.
+ *
+ * GS1's own rule is that a GTIN is a number, not a string: shorter forms are
+ * the same identifier left-padded with zeros. So everything is widened to
+ * GTIN-14 and compared there.
+ */
+
+/** Digits only, widened to GTIN-14. Returns undefined if it is not a GTIN. */
+export function toGtin14(raw?: string | number | null): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const digits = String(raw).replace(/\D/g, '').replace(/^0+/, '');
+  if (!digits) return undefined;
+  // GTIN-8, -12, -13 and -14 are the only valid lengths. Anything else is an
+  // internal product code that happens to be numeric — a Tesco TPNB, say — and
+  // treating one of those as a barcode is worse than having none, because it
+  // silently matches nothing while looking authoritative.
+  if (digits.length > 14 || ![8, 12, 13, 14].includes(digits.length)) return undefined;
+  return digits.padStart(14, '0');
+}
+
+/**
+ * GS1 mod-10 check digit. The last digit of a GTIN is derived from the rest,
+ * so a transposed or truncated code is detectable rather than merely wrong.
+ */
+export function isValidGtin(raw?: string | number | null): boolean {
+  const g = toGtin14(raw);
+  if (!g) return false;
+  const body = g.slice(0, 13);
+  let sum = 0;
+  for (let i = 0; i < 13; i++) {
+    // Weights alternate 3,1,... from the LEFT of a 13-digit body.
+    sum += Number(body[i]) * (i % 2 === 0 ? 3 : 1);
+  }
+  return (10 - (sum % 10)) % 10 === Number(g[13]);
+}
+
+/** Normalise, and drop anything that fails its own check digit. */
+export function cleanGtin(raw?: string | number | null): string | undefined {
+  const g = toGtin14(raw);
+  return g && isValidGtin(g) ? g : undefined;
+}

--- a/src/providers/sainsburys.ts
+++ b/src/providers/sainsburys.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { cleanGtin } from './gtin.js';
 import { GroceryProvider, Product, Basket, DeliverySlot, Order, SearchOptions, BasketItem } from './types';
 import { login } from '../auth/login';
 import * as fs from 'fs';
@@ -124,7 +125,12 @@ export class SainsburysProvider implements GroceryProvider {
       unit_price: p.unit_price,
       in_stock: p.in_stock !== false && p.is_available !== false,
       image_url: p.image || p.assets?.plp_image,
-      provider: this.name
+      provider: this.name,
+      // Sainsbury's returns `eans: ["5000157026071"]` on every product and it
+      // was being dropped here. An array because a product can carry more than
+      // one barcode (a multipack and its inner unit); the first is the one that
+      // scans at the till.
+      gtin: cleanGtin(p.eans?.[0])
     };
   }
 

--- a/src/providers/tesco/index.ts
+++ b/src/providers/tesco/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { GroceryProvider, Product, Basket, DeliverySlot, Order, SearchOptions, BasketItem } from '../types';
+import { cleanGtin } from '../gtin.js';
 import { TescoAPI } from './api';
 import { login, loadSession, clearSession, getCookieString } from './auth';
 
@@ -260,6 +261,11 @@ export class TescoProvider implements GroceryProvider {
 
     return {
       product_uid: String(p?.id || p?.gtin || ''),
+      // The GraphQL query has always selected `gtin`; it was only ever used as
+      // a fallback for product_uid, which never fires because `id` is present.
+      // product_uid must stay the internal id — basket operations address
+      // products by it — so the barcode gets its own field.
+      gtin: cleanGtin(p?.gtin),
       name: p?.title || p?.name || 'Unknown product',
       description: Array.isArray(p?.description?.features)
         ? p.description.features.join('; ')

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -24,6 +24,20 @@ export interface Product {
   rating?: number;       // 0-5 overall rating, when the provider exposes it
   review_count?: number; // number of ratings behind `rating`
   size?: string;         // pack size, e.g. "750g", "6 pack"
+  /**
+   * GTIN-14, when the provider exposes a real barcode.
+   *
+   * This is the only field that means the same thing at two different
+   * retailers, so it is what turns "compare these baskets" from fuzzy name
+   * matching into an exact join — the same argument the Kroger provider
+   * already makes for Open Food Facts enrichment. Own-label lines have no
+   * shared barcode by definition and simply leave it undefined.
+   *
+   * Always normalised through `gtin.ts` to GTIN-14 and check-digit validated,
+   * because providers disagree about zero-padding: Tesco returns
+   * `05000157024671`, Sainsbury's `5000157026071`.
+   */
+  gtin?: string;
 }
 
 export interface BasketItem {

--- a/test/gtin.test.ts
+++ b/test/gtin.test.ts
@@ -1,0 +1,76 @@
+/**
+ * GTIN normalisation.
+ *
+ * The point of the field is that two providers' barcodes are comparable, so
+ * the thing worth asserting is that Tesco's zero-padded form and Sainsbury's
+ * bare EAN-13 land on the same string for the same product.
+ *
+ * Offline, no credentials, no network — the CI contract.
+ *
+ * Run: npx tsx test/gtin.test.ts
+ */
+
+import assert from 'node:assert';
+import { toGtin14, isValidGtin, cleanGtin } from '../src/providers/gtin.js';
+
+let failures = 0;
+function check(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${err.message}`);
+  }
+}
+
+console.log('gtin');
+
+// The reason this module exists: same product, two shapes, one identity.
+check('Tesco padding and a bare EAN-13 normalise to the same GTIN-14', () => {
+  assert.strictEqual(toGtin14('05000157024671'), toGtin14('5000157024671'));
+  assert.strictEqual(toGtin14('5000157024671'), '05000157024671');
+});
+
+check('shorter GTIN forms widen to 14', () => {
+  assert.strictEqual(toGtin14('96385074'), '00000096385074');       // GTIN-8
+  assert.strictEqual(toGtin14('614141000036'), '00614141000036');   // GTIN-12
+});
+
+check('an internal product code is not a barcode', () => {
+  // 🔴 THIS IS WHY THE MAPPERS CALL cleanGtin AND NOT toGtin14.
+  //
+  // An Ocado SKU like 78914011 is eight digits, which is a legal GTIN-8
+  // LENGTH — so normalisation alone accepts it and hands back something that
+  // looks authoritative and matches nothing. Only the check digit tells the
+  // two apart, and a wrong barcode is worse than no barcode: it silently
+  // fails to join instead of falling back to a name match.
+  assert.strictEqual(toGtin14('78914011'), '00000078914011');
+  assert.strictEqual(cleanGtin('78914011'), undefined);
+  // Too long to be any GTIN form.
+  assert.strictEqual(toGtin14('1234567890123456'), undefined);
+});
+
+check('empty and junk are undefined, not a crash', () => {
+  for (const v of [undefined, null, '', '   ', 'abc', 0]) {
+    assert.strictEqual(toGtin14(v as any), undefined);
+  }
+});
+
+check('the GS1 check digit is enforced', () => {
+  assert.ok(isValidGtin('5000157024671'), 'real Heinz EAN-13 should validate');
+  assert.ok(isValidGtin('05000157024671'), 'same code, zero-padded');
+  assert.ok(!isValidGtin('5000157024672'), 'last digit altered');
+  assert.ok(!isValidGtin('5000157026071'.replace('26', '62')), 'transposed digits');
+});
+
+check('cleanGtin drops anything that fails its own check digit', () => {
+  assert.strictEqual(cleanGtin('5000157024671'), '05000157024671');
+  assert.strictEqual(cleanGtin('5000157024672'), undefined);
+});
+
+if (failures) {
+  console.error(`\n${failures} failing`);
+  process.exit(1);
+}
+console.log('\nall passing');


### PR DESCRIPTION
## The problem

Both UK providers hand back a real GTIN and both throw it away, so a caller who wants to line one product up across two retailers has only the name to go on — and names don't survive the trip:

- `Heinz Baked Beans in Tomato Sauce 4 x 200g` (Tesco) vs `...4x200g` (Sainsbury's)
- a search for `salted butter 250g` returns **Sainsbury's Lard 250g**
- a search for `butter` returns **I Can't Believe It's Not Butter** spread

## What was already there

**Tesco is the odd one.** Its GraphQL query has always selected `gtin`, and the value is only used as a fallback for `product_uid` — which never fires, because `id` is always present. The barcode is fetched on every search and discarded:

```ts
product_uid: String(p?.id || p?.gtin || ''),
```

**Sainsbury's** returns `eans: ["5000157026071"]` on every raw product; `mapProduct` drops it.

## The change

- `Product.gtin?: string` — a new optional field. `product_uid` is untouched, because basket operations address products by it.
- `src/providers/gtin.ts` — normalisation. The two providers disagree about shape: Tesco zero-pads to 14, Sainsbury's returns a bare EAN-13, so as raw strings they never match. Both widen to GTIN-14, which is GS1's own rule that shorter forms are the same identifier left-padded.
- **Check digits are enforced**, and that part is load-bearing rather than tidiness. An Ocado SKU like `78914011` is eight digits — a legal GTIN-8 *length* — so normalisation alone would return something authoritative-looking that matches nothing. mod-10 tells them apart. A wrong barcode is worse than none: it silently fails to join instead of falling back to a name match.

This is the argument `kroger.ts` already makes for Open Food Facts enrichment — *"turns enrichment from a fuzzy name guess into an exact lookup"* — applied to the two UK providers that were already carrying the data.

## Verified live

One query, `heinz baked beans`, both providers:

| GTIN | Tesco | Sainsbury's | product |
|---|---|---|---|
| 05000157024886 | £3.90 | £3.90 | 4 x 415g |
| **05000157150974** | **£3.95** | **£3.25** | 6 x 200g |
| 05000157150431 | £2.75 | £2.75 | 4 x 200g |
| 05000157066312 | £3.50 | £3.50 | Snap Pots 4 x 200g |
| 05000157004017 | £0.65 | £0.65 | 150g |

Five exact joins, and a 70p difference on the 6x200g that no name match would have been trusted to find.

## Ocado

Left alone rather than faked. It exposes no barcode — neither its search entities nor its product-page JSON-LD carry one; the `sku` there is Ocado's own reference (`78914011`).

Separately, and happy to send it as a follow-up PR if useful: Ocado's search entities **do** carry `guaranteedProductLife` (`{quantity: 6, unit: "DAY"}`) and `attributes` (`freezable`, `microwavable`, `organic`), both currently dropped in `mapEntity`. The first is real per-pack shelf life, which is hard to get any other way.

## Tests

`test/gtin.test.ts`, wired into `npm test`. Offline, no credentials, no network — per the CI contract in `ci.yml`. `npm run typecheck` clean.