### PR TITLE
Make Open Supermarkets launch-ready

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report incorrect or broken Open Supermarkets behaviour
+title: "[bug] "
+labels: []
+body:
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      placeholder: e.g. Tesco
+
+  - type: input
+    id: command
+    attributes:
+      label: Command / interface
+      placeholder: e.g. supermarket search milk --provider tesco, MCP grocery_search, HTTP /search
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include redacted output or errors where useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Give the smallest sequence that reproduces the problem.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      placeholder: e.g. 3.0.0
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, country/region and anything else relevant. Do not include private account details.
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety
+      options:
+        - label: I have removed passwords, API secrets, session cookies, addresses, payment data and private order data.
+          required: true
+        - label: This report does not contain an undisclosed exploitable security vulnerability. If it does, I will follow SECURITY.md instead.
+          required: true

--- a/.github/ISSUE_TEMPLATE/provider-request.yml
+++ b/.github/ISSUE_TEMPLATE/provider-request.yml
@@ -1,0 +1,70 @@
+name: Supermarket / provider request
+description: Propose a retailer or country for Open Supermarkets
+title: "[provider] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping expand Open Supermarkets. Before filing this, check `docs/providers/evaluated.md` so we do not repeat an investigation that is already documented.
+
+  - type: input
+    id: retailer
+    attributes:
+      label: Retailer
+      placeholder: e.g. Lidl
+    validations:
+      required: true
+
+  - type: input
+    id: country
+    attributes:
+      label: Country / region
+      placeholder: e.g. Germany
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: What would you like to do?
+      description: Search, store stock, basket, slots, checkout, order history, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: research
+    attributes:
+      label: What have you verified?
+      description: Share public endpoints, app/web behaviour or protocol observations. Do not paste credentials, cookies or private account data.
+
+  - type: dropdown
+    id: can-test
+    attributes:
+      label: Can you test this retailer with a real account or local store?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: maintain
+    attributes:
+      label: Would you be willing to contribute or maintain the provider?
+      options:
+        - "Yes"
+        - "Maybe"
+        - "No"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I checked `docs/providers/evaluated.md` first.
+          required: true
+        - label: I have not included passwords, API secrets, session cookies, addresses, payment data or private order data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## What changed
+
+<!-- What problem does this PR solve? -->
+
+## Verification
+
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] `npm test`
+
+### Live verification
+
+<!-- What was tested against a real retailer/provider? Say "not tested live" rather than implying verification. -->
+
+### Offline verification
+
+<!-- Tests, fixtures, clean install, MCP/CLI/HTTP smoke tests, etc. -->
+
+## Capability / safety review
+
+- [ ] The provider only declares capabilities that are actually implemented.
+- [ ] Unknown stock/pricing/state is preserved rather than invented.
+- [ ] Checkout or other spend paths remain preview/dry-run by default.
+- [ ] No credentials, cookies, addresses, payment data or private order data are included.
+- [ ] Upstream protocol/research sources are credited where relevant.
+
+## Known limitations
+
+<!-- Region assumptions, bot protection, unsupported capabilities, authentication caveats, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to Open Supermarkets
+
+Open Supermarkets is most useful when people contribute the retailers they can actually test.
+
+The goal is not to collect as many provider names as possible. The goal is a trustworthy interface that agents and humans can rely on without inventing capabilities or silently returning nonsense.
+
+## Good contributions
+
+- a new supermarket provider you can verify against the live retailer;
+- fixes for a provider that changed upstream;
+- tests for regional catalogue, pricing or authentication behaviour;
+- improvements to the CLI, HTTP, MCP or skill interfaces;
+- examples of real projects built on Open Supermarkets;
+- documentation that removes a genuine setup or debugging trap.
+
+Before investigating a new retailer, read `docs/providers/evaluated.md`. Failed probes are documented so contributors do not repeatedly lose weekends to the same WAF, mTLS requirement or dead endpoint.
+
+## Adding a provider
+
+A search-only provider can be deliberately small. At minimum it needs a provider implementation and a registry entry.
+
+```ts
+export class MySupermarketProvider {
+  readonly name = 'mysupermarket';
+  async search(query: string, opts?: SearchOptions): Promise<Product[]> {
+    // return truthful, normalised product data
+  }
+}
+```
+
+Use `src/providers/ah.ts` as a reference for a compact anonymous-search integration.
+
+When registering a provider:
+
+- declare only capabilities you have implemented and tested;
+- set the correct country and authentication model;
+- identify a maintainer;
+- use `community` for integrations that are not maintained by the core project;
+- add protocol/research credit where another project helped you understand an undocumented interface.
+
+## Verification contract
+
+A PR should make it possible for a reviewer to distinguish verified behaviour from assumptions.
+
+Include:
+
+1. What you tested live.
+2. What you could only test offline.
+3. Any region/store/account assumptions that affect pricing or availability.
+4. What deliberately remains unsupported.
+5. Commands or fixtures that reproduce the behaviour without exposing credentials.
+
+Run before opening a PR:
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+npm test
+```
+
+CI is designed to run without retailer credentials so PRs from forks remain verifiable.
+
+## Correctness rules
+
+### Unknown is better than invented
+
+If stock, price, product identity or a capability cannot be established, preserve that uncertainty. Do not turn missing data into `false`, zero, an empty basket or another authoritative-looking value unless that is genuinely what the retailer returned.
+
+### Spending must be explicit
+
+Checkout and other actions that can spend money must fail safe. Preview/dry-run behaviour is the default. Never weaken an existing confirmation boundary for convenience.
+
+### Errors should be actionable
+
+Do not swallow authentication failures, WAF responses or upstream errors and return an empty result. An agent will treat an empty result as truth. Surface enough context for a human or agent to understand what happened.
+
+### Keep agent payloads lean
+
+The model needs identifiers, names, prices, sizes, stock and other decision-relevant fields. Avoid pushing decorative or redundant retailer payloads through MCP simply because the upstream API returned them.
+
+## Credentials and private data
+
+Never commit or paste into issues/PRs:
+
+- passwords;
+- API secrets;
+- session cookies;
+- complete request headers containing authentication;
+- addresses;
+- payment information;
+- private order data.
+
+Use environment variables, local fixtures with fake values and redacted examples.
+
+If you discover a security vulnerability, follow `SECURITY.md` rather than publishing exploit details in a public issue.
+
+## Pull requests
+
+Keep PRs scoped enough to review. A provider addition can be substantial, but unrelated refactors make live integration changes unnecessarily difficult to reason about.
+
+A useful PR description explains the problem, the protocol/behaviour discovered, the change, live verification, offline tests and known limitations.
+
+Contributors who maintain a provider are encouraged to put their GitHub handle in the registry. Reverse-engineered integrations stay healthy through ownership, not optimism.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 # open&#8203;-supermarkets
 
-### One command line for the world's supermarkets
+### The open-source grocery interface for humans and AI agents
 
-**Search real products at real prices, build a basket, book a slot, check out —<br>across nine providers in six countries. Built for AI agents.**
+**Search live products and prices, compare retailers, build baskets and check out safely<br>across nine providers in six countries.**
+
+**CLI · HTTP API · MCP · Agent Skills**
 
 <br>
 
@@ -12,16 +14,20 @@
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Countries](https://img.shields.io/badge/countries-6-2ea44f)](#what-works-where)
 [![Providers](https://img.shields.io/badge/providers-9-2ea44f)](#what-works-where)
-[![No credentials](https://img.shields.io/badge/3%20of%206%20countries-no%20credentials-orange)](#what-works-where)
+[![No credentials](https://img.shields.io/badge/3%20countries-no%20credentials-orange)](#what-works-where)
 [![CI](https://github.com/abracadabra50/open-supermarkets/actions/workflows/ci.yml/badge.svg)](https://github.com/abracadabra50/open-supermarkets/actions/workflows/ci.yml)
-[![MCP](https://img.shields.io/badge/MCP-22%20tools-6E56CF)](#three-ways-to-drive-it)
+[![MCP](https://img.shields.io/badge/MCP-22%20tools-6E56CF)](#connect-an-agent)
 [![Stars](https://img.shields.io/github/stars/abracadabra50/open-supermarkets?style=flat&color=yellow)](https://github.com/abracadabra50/open-supermarkets/stargazers)
 
-🇬🇧 &nbsp;🇳🇱 &nbsp;🇧🇪 &nbsp;🇪🇸 &nbsp;🇺🇸 &nbsp;🇨🇦 &nbsp;&nbsp;·&nbsp;&nbsp; [**your country next?**](#we-want-your-supermarket)
+🇬🇧 &nbsp;🇳🇱 &nbsp;🇧🇪 &nbsp;🇪🇸 &nbsp;🇺🇸 &nbsp;🇨🇦 &nbsp;&nbsp;·&nbsp;&nbsp; [**your country next?**](#bring-your-supermarket)
 
 </div>
 
 ---
+
+> **The demo to build:** “Plan five high-protein family dinners under £60. No pork, no nuts. Compare Tesco, Sainsbury's and Ocado, choose sensible pack sizes, build the basket and show me before checkout.”
+>
+> A short end-to-end demo belongs here. If you build one with Open Supermarkets, open a PR and we'll feature it.
 
 ```console
 $ supermarket compare milk
@@ -36,28 +42,28 @@ $ supermarket search melk --country NL
   Campina Halfvolle melk           €1.89 / 1,5 l
 ```
 
-**Three of the six countries need no credentials at all.** No key, no account, no
-signup — Spain, the Netherlands and Belgium answer an anonymous request.
+**Spain, the Netherlands and Belgium need no credentials at all.** No key, no account,
+no signup. You can query a real supermarket catalogue immediately.
 
 ---
 
-## Why this exists
+## Try it
 
-Supermarkets have no public API. So every meal planner, price tracker and shopping
-agent reimplements the same brittle integration from scratch, for one country, and
-abandons it six months later.
+```bash
+npx open-supermarkets providers
+npx open-supermarkets search "olive oil" --country ES --limit 5
+```
 
-This is that layer, done once, in the open. Your agent decides *what* to buy. This
-works out *where*, *how much*, and *how to actually order it*.
-
----
-
-## Install
+Or install it globally:
 
 ```bash
 npm install -g open-supermarkets
 supermarket providers
 ```
+
+The canonical command is `supermarket`; `open-supermarkets` is an npm-friendly alias.
+The old `groc` alias remains temporarily for backwards compatibility and will disappear
+in v4.
 
 From source:
 
@@ -67,16 +73,88 @@ cd open-supermarkets && npm install && npm link
 npx playwright install chromium   # only for browser-auth providers
 ```
 
-The command is `supermarket`. If you used this when it was UK-only, `groc` still works
-and prints a deprecation notice — it's going in v4, because the unrelated `groc` npm
-package ships its own `groc` binary and the two can't share a PATH.
+---
+
+## What it lets an agent do
+
+A shopping agent should decide *what* makes sense for the person. Open Supermarkets
+handles the ugly retail plumbing underneath it:
+
+- search real supermarket catalogues and current prices;
+- compare retailers without forcing every agent to build retailer integrations;
+- build and mutate live baskets where the provider supports it;
+- inspect delivery slots and order history;
+- enrich products with nutrition and allergen data;
+- preview checkout safely before any money is spent.
+
+Supermarkets rarely expose public shopper APIs. Without a shared layer, every meal
+planner, price tracker and shopping agent reimplements the same brittle integration
+for one retailer and eventually abandons it. This is that layer, done once, in the open.
+
+---
+
+## Connect an agent
+
+### MCP
+
+For Claude Desktop, Cursor or anything speaking Model Context Protocol:
+
+```json
+{
+  "mcpServers": {
+    "groceries": {
+      "command": "npx",
+      "args": ["-y", "open-supermarkets", "mcp"]
+    }
+  }
+}
+```
+
+If you install the package globally, use `supermarket-mcp` directly.
+
+A useful first prompt:
+
+> *Plan a week of high-protein dinners, no pork and no nuts. Price the shop at Tesco, show me the basket and do not place an order.*
+
+The server exposes 22 tools, including batch primitives designed to stop agents burning
+one tool call per ingredient:
+
+| MCP tool | Purpose |
+|---|---|
+| `grocery_search` · `grocery_compare` | Find and compare products |
+| **`grocery_search_batch`** · **`grocery_basket_add_batch`** | **Many at once — prefer these** |
+| `grocery_basket_*` | View, add, remove, update, clear |
+| `grocery_slots` · `grocery_book_slot` | Delivery slots |
+| `grocery_checkout` | Preview/place an order; `dry_run` defaults to **true** |
+| `grocery_favourites` · `ocado_regulars` · `tesco_staples` | Repeat-purchase lists |
+| `grocery_orders` | Order history |
+
+### Agent skills
+
+[`SKILL.md`](SKILL.md) is the top-level skill. [`skills/`](skills/) contains provider
+skills for the quirks that actually matter: Tesco cookie import, Ocado category paths,
+Sainsbury's favourites and more. Drop them into Claude Code, OpenClaw or another harness
+that reads `SKILL.md`.
+
+### HTTP
+
+`supermarket-api` exposes the same core capabilities over plain HTTP for agents that
+have network access but cannot execute local commands.
+
+### CLI
+
+Everything ultimately rests on a scriptable CLI contract:
+
+```bash
+supermarket search "olive oil" --country ES --limit 5 --json
+```
 
 ---
 
 ## What works where
 
-Providers declare what they can do. Search needs no account almost anywhere; checkout
-needs an account, an address and a card, so it exists for fewer.
+Providers declare what they can actually do. Search needs no account almost everywhere;
+checkout needs an account, address and payment method, so it exists for fewer.
 
 | Provider | Country | Search | Basket | Slots | Checkout | Auth |
 |---|---|:-:|:-:|:-:|:-:|---|
@@ -90,58 +168,19 @@ needs an account, an address and a card, so it exists for fewer.
 | Instacart | 🇺🇸 🇨🇦 | ✓ | ✓ | — | via link | partner key |
 | Instacart *(unofficial)* | 🇺🇸 🇨🇦 | ✓ | ✓ | — | — | browser session |
 
-`supermarket providers` prints this live from the registry, so it can't drift from
-reality the way a hand-maintained table does.
+`supermarket providers` prints this live from the registry. The manifest is the source
+of truth rather than a hand-maintained marketing claim.
 
-Ocado's slot *booking* and checkout are blocked by AWS WAF. Reading slots works;
-committing to one doesn't. The manifest doesn't claim the capability — which is why
-you see a dash rather than a footnote.
-
----
-
-## Three ways to drive it
-
-**It's a CLI first.** Everything else wraps that. Commands are the contract — they're
-stable, scriptable, and work from anything that can shell out.
-
-```bash
-supermarket search "olive oil" --country ES --limit 5 --json
-```
-
-**As an MCP server**, for Claude, Cursor or anything speaking the protocol:
-
-```json
-{ "mcpServers": { "groceries": { "command": "supermarket-mcp" } } }
-```
-
-> *"Plan a week of high-protein dinners, no pork, no nuts, and price the shop at Tesco."*
-
-| MCP tool | |
-|---|---|
-| `grocery_search` · `grocery_compare` | Find and compare products |
-| **`grocery_search_batch`** · **`grocery_basket_add_batch`** | **Many at once — prefer these** |
-| `grocery_basket_*` | View, add, remove, update, clear |
-| `grocery_slots` · `grocery_book_slot` | Delivery slots |
-| `grocery_checkout` | Place the order — `dry_run` defaults to **true** |
-| `grocery_favourites` · `ocado_regulars` · `tesco_staples` | Repeat-purchase lists |
-| `grocery_orders` | Order history |
-
-**As agent skills.** [`SKILL.md`](SKILL.md) is the top-level skill; [`skills/`](skills/)
-holds per-provider ones with the quirks that matter — Tesco's cookie import, Ocado's
-category paths, Sainsbury's favourites. Drop them into Claude Code, OpenClaw, or
-anything that reads `SKILL.md`.
-
-There's also `supermarket-api`, a plain HTTP server, for agents with network access but
-no filesystem.
+Ocado slot booking and checkout are blocked by AWS WAF. Reading slots works; committing
+to one does not. The manifest therefore does not claim those capabilities.
 
 ---
 
-## Batch mode — built for how agents actually work
+## Built for how agents actually work
 
-A week of meals is about thirty ingredients. One at a time that's thirty searches plus
-thirty adds: sixty process starts, sixty MCP round trips, sixty tool results filling
-the model's context. The agent spends its budget on plumbing instead of on deciding
-what to cook.
+A week of meals can mean thirty ingredients. One at a time, that becomes thirty searches
+plus thirty basket writes: sixty process starts, sixty MCP round trips and sixty tool
+results filling the model's context.
 
 ```console
 $ echo '["semi skimmed milk","free range eggs","chicken breast","broccoli"]' \
@@ -152,80 +191,43 @@ $ echo '["semi skimmed milk","free range eggs","chicken breast","broccoli"]' \
 {
   "provider": "ocado",
   "results": [
-    { "query": "semi skimmed milk",
-      "products": [{ "id": "73f814b7", "name": "Ocado British Semi Skimmed Milk 2 Pints",
-                     "price": 1.20, "currency": "GBP", "size": "1.136L",
-                     "unit": "1.06/1.136L", "inStock": true }] }
+    {
+      "query": "semi skimmed milk",
+      "products": [
+        {
+          "id": "73f814b7",
+          "name": "Ocado British Semi Skimmed Milk 2 Pints",
+          "price": 1.20,
+          "currency": "GBP",
+          "size": "1.136L",
+          "unit": "1.06/1.136L",
+          "inStock": true
+        }
+      ]
+    }
   ]
 }
 ```
 
-Then pick, and add them all in one call:
+Then let the model choose using the context it already has and add its picks together:
 
 ```bash
-supermarket add --batch picks.json     # [{"id":"73f814b7","qty":2}, ...]
+supermarket add --batch picks.json
 ```
 
-Six queries take **1.7s in one invocation** rather than six. Input is forgiving — a
-JSON array, an object with `queries`, or newline-delimited text from a pipe.
+Batch search returns candidates. **It deliberately does not decide what to buy.** The
+model knows the meal plan, budget, dietary constraints and whether leftovers are useful;
+the supermarket integration does not.
 
-Output is deliberately **lean**: id, name, price, currency, size, unit price, stock.
-No images, no descriptions, no ratings. Thirty queries by five candidates by a full
-product record is a serious slice of a context window, and none of it helps a model
-choose between two milks.
-
-**Batch search returns candidates. It does not choose.** Picking a 650g pack for a
-200g recipe is a judgement about your money and your fridge, and the model has context
-the CLI never will — the rest of the plan, the budget, whether leftovers are fine. One
-bad query returns an `error` on its own entry rather than sinking the batch. Adds run
-sequentially, because baskets are mutable server-side state and concurrent writes race.
+Provider code is also lazy-loaded. Shopping in the UK does not load Spanish provider
+code or pay Playwright startup cost for a retailer you never use.
 
 ---
 
-## Only pay for the country you're in
+## Nutrition and allergens
 
-Providers are declared in a manifest; their code loads on demand. Shopping in the UK
-never loads the Spanish provider, and never pays Playwright's startup cost for a
-retailer you don't use.
-
-```ts
-import { list, createProvider } from 'open-supermarkets';
-
-list({ country: 'ES', capability: 'search' });   // loads no provider code at all
-const m = await createProvider('mercadona');     // loads exactly one
-```
-
-Country comes from `--country`, then `SUPERMARKET_COUNTRY`, then your system locale.
-
----
-
-## Nutrition and allergens, everywhere
-
-`--enrich` adds Nutri-Score, NOVA processing group, allergens and ingredients from
-[Open Food Facts](https://openfoodfacts.org) — every provider, every country, no key.
-
-```console
-$ supermarket search "semi skimmed milk 2l" --provider tesco --enrich
-  Tesco Semi Skimmed Milk 2L   £1.45
-    Nutri-Score B · allergens: milk · matched by barcode
-```
-
-**It is deliberately conservative and will often tell you nothing.** That's the design.
-Matching is by barcode where a provider exposes one, by name where it doesn't — and a
-name match must clear a strict guard:
-
-- A **variant marker** on one side and not the other is disqualifying. "Zero" versus
-  regular is a different product however well the rest matches.
-- Sharing only a **category word** isn't evidence. "Chocolate" matches everything
-  chocolatey and means nothing.
-- Only the **top candidate** is considered. Scoring the top five was tried and reverted
-  — it immediately matched a Coca-Cola Zero query to a regular-Coke record.
-
-The cost is real misses. A Nutella jar from a UK provider gets nothing, because Open
-Food Facts returns an unrelated product at position one. That's the right trade: **a
-miss shows nothing, a false positive shows the wrong allergens.**
-
-**Kroger and Mercadona expose barcodes, so their matches are exact rather than guessed:**
+`--enrich` adds Nutri-Score, NOVA processing group, allergens and ingredients using
+[Open Food Facts](https://openfoodfacts.org) across every provider and country.
 
 ```console
 $ supermarket search nutella --provider kroger --enrich
@@ -233,23 +235,24 @@ $ supermarket search nutella --provider kroger --enrich
     Nutri-Score E · NOVA 4 · allergens: milk, nuts, soybeans · matched by barcode
 ```
 
-Kroger's `upc` field needed reconstructing first — it's the 11-digit product code
-padded to 13 with the UPC-A check digit dropped, so it resolves to nothing as supplied.
-One missing digit was the difference between exact allergen data and a name guess.
+Matching is intentionally conservative. Where a provider exposes a barcode, the lookup
+can be exact. Where it does not, name matching must clear strict guards. A miss shows
+nothing; a false positive can show the wrong allergen, which is much worse.
 
-Never rely on it for an allergy. Read the packet.
+Never rely on it as medical or allergy advice. Check the product packaging.
 
 ---
 
-## We want your supermarket
+## Bring your supermarket
 
-**This is the part we'd most like help with.** Nine providers, five countries — and
-there are a lot more countries. If you shop somewhere that isn't here, you are better
-placed to add it than anyone else, because you can actually test it.
+This project gets more useful when people add the supermarket they can actually test.
+A search-only provider can be one file plus one manifest entry.
 
-A search-only provider is **one file and one manifest entry**. Roughly an afternoon.
+Before starting, read [`docs/providers/evaluated.md`](docs/providers/evaluated.md). It
+records providers already investigated, what worked, what failed and when. That avoids
+every contributor rediscovering the same bot wall or dead endpoint.
 
-**1. Write it.** Only `name` and `search()` are required.
+The minimum provider shape is intentionally small:
 
 ```ts
 export class MySupermarketProvider {
@@ -258,77 +261,59 @@ export class MySupermarketProvider {
 }
 ```
 
-**2. Register it** in `src/providers/registry.ts`:
+Register it in `src/providers/registry.ts`, add tests that run without credentials, and
+open a PR. [`src/providers/ah.ts`](src/providers/ah.ts) is a useful reference for a small
+anonymous-search provider.
 
-```ts
-{
-  id: 'mysupermarket',
-  label: 'My Supermarket',
-  country: 'DE',
-  capabilities: ['search'],
-  auth: 'none',
-  tier: 'community',
-  maintainer: 'your-github-handle',
-  load: async () => (await import('./mysupermarket')).MySupermarketProvider,
-}
-```
-
-**3. Open a PR.** [`src/providers/ah.ts`](src/providers/ah.ts) is the reference —
-anonymous token, catalogue search, ~150 lines, no account required. A `skills/` entry
-for anything non-obvious about your provider is welcome but not required.
-
-**Read [`docs/providers/evaluated.md`](docs/providers/evaluated.md) first** so you don't
-lose a weekend. It records what's already been probed and exactly why it failed: REWE
-needs mTLS certificates extracted from its APK, Jumbo refuses the TLS handshake,
-DoorDash and Woolworths serve bot challenges, Loblaws returns 403, Tesco Ireland uses
-separate client credentials. Rejections are dated — an old "no" is a reason to re-probe,
-not to stop.
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution contract.
 
 ### The rules that stop this rotting
 
-- **Every provider has a maintainer of record.** Keeping dozens of reverse-engineered
-  integrations alive is not one person's job. No maintainer, provider goes red, then
-  archived. A status, not a judgement.
-- **`core` is maintained here and CI-tested. `community` is best-effort**, labelled as
-  such in the CLI so nobody is surprised at checkout.
-- **Declare only what you implement.** A provider claiming a `checkout` it has never run
-  is worse than one claiming nothing.
-- **Credit the protocol.** If you learned the endpoints from someone else's reverse
-  engineering, put it in the manifest's `credit` field. We do.
+- Every provider has a maintainer of record.
+- `core` integrations are maintained here and CI-tested; `community` integrations are best-effort and labelled as such.
+- Declare only capabilities that have actually been implemented and verified.
+- Credit protocol research you learned from rather than quietly absorbing it.
+- Never put retailer credentials, session cookies or payment data in issues, tests or commits.
 
 ---
 
 ## Honest caveats
 
-**Most of these are unofficial integrations.** Retailers change their APIs without
-notice and some deploy bot protection. A red provider is usually that, not your setup.
+**Most integrations are unofficial.** Retailers change APIs without notice and some
+deploy bot protection. A red provider can mean the retailer changed, not your setup.
 
-**Automated access may conflict with a retailer's terms of service.** This is built for
-personal automation — your account, your shopping. Read the terms and make your own
-call.
+**Automated access may conflict with retailer terms.** This project is intended for
+personal automation of your own shopping. Understand the terms that apply to you.
 
 **Checkout previews by default.** `supermarket checkout` shows the order and places
-nothing; spending real money needs `--confirm`, explicitly. The MCP tool defaults
-`dry_run` to true. Three tests pin that, because a one-character regression is
-somebody's shopping.
+nothing. Spending money requires `--confirm`; the MCP checkout tool defaults to
+`dry_run: true`.
 
-**Sessions expire.** Cookie-auth providers need re-importing periodically. When Tesco's
-session dies, search says so — silently returning an empty list, as if the shelves were
-bare, was a real bug and is now a loud error.
+**Sessions expire.** Cookie-auth providers need re-importing periodically. Authentication
+failures are surfaced explicitly rather than masquerading as empty search results.
+
+For security-sensitive reports, read [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Built with Open Supermarkets
+
+Using this in an agent, meal planner, price tracker, Alexa workflow or something stranger?
+Open a PR adding it here. Real implementations are far more useful than another invented
+example.
 
 ---
 
 ## Credits
 
-Protocol knowledge — reimplemented, not copied — from:
+Protocol knowledge, reimplemented rather than copied, from:
 
 - [gwillem/appie-go](https://github.com/gwillem/appie-go) — Albert Heijn (Go, MIT)
 - [kleinjm/instacart_api](https://github.com/kleinjm/instacart_api) — Instacart web (Ruby, MIT)
 - [CupOfOwls/kroger-api](https://github.com/CupOfOwls/kroger-api) — Kroger (Python, MIT)
 - [Open Food Facts](https://openfoodfacts.org) — global product data (ODbL)
 
-Open Food Facts is a nonprofit, and the enrichment layer is free because volunteers
-scanned several million products. If this is useful to you,
-[donate to them](https://donate.openfoodfacts.org).
+Open Food Facts is a nonprofit. If this project is useful to you, consider supporting
+the volunteers maintaining that dataset.
 
-MIT. Not affiliated with, endorsed by, or connected to any retailer named here.
+MIT. Not affiliated with, endorsed by or connected to any retailer named here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+Open Supermarkets interacts with retailer accounts, authenticated browser sessions, baskets and, for some providers, checkout flows. Treat credentials and session material as secrets with the same care you would give the retailer account itself.
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue containing an exploitable vulnerability, retailer credentials, session cookies, payment information or another user's private data.
+
+For a security-sensitive report, use GitHub's private vulnerability reporting feature for this repository when it is available. If private reporting is not available, open a minimal public issue stating that you have a security report to share, without including exploit details or secrets, so a private channel can be established.
+
+A useful report includes:
+
+- affected provider or component;
+- affected version/commit;
+- impact;
+- minimal reproduction steps with secrets removed;
+- whether the issue can spend money, mutate a live basket, expose authentication material or cross an account boundary.
+
+## Safety boundaries
+
+The project treats the following as security-sensitive invariants:
+
+### Checkout is fail-safe
+
+Checkout must preview/dry-run by default. Spending real money requires an explicit confirmation path. Changes that weaken this boundary should be treated as security changes and reviewed accordingly.
+
+### Credentials stay local
+
+Passwords, API keys and retailer session cookies must never be logged, committed, embedded in fixtures or returned through agent tool output.
+
+Session files should use restrictive local file permissions where supported.
+
+### Empty data must not hide authentication failure
+
+An expired session or blocked request must not silently become an empty search result, empty order history or empty basket. Agents can act on those values as if they are authoritative.
+
+### External retailer content is untrusted
+
+Product names, descriptions and other retailer-controlled strings are data, not instructions. Agent integrations should not treat content returned by a retailer as trusted executable guidance.
+
+## Supported versions
+
+Security fixes target the current release and the `main` branch. This project integrates with undocumented and changing retailer interfaces, so old releases can stop working independently of the core package.
+
+## Secrets accidentally committed
+
+If a real credential or session cookie is committed, assume it is compromised even if the commit is subsequently removed. Revoke or rotate it at the retailer/provider first; history rewriting is not a substitute for invalidating the credential.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "open-supermarkets",
   "version": "3.0.0",
-  "description": "CLI, MCP and Skills for the world's supermarkets. Search, compare, basket and checkout across 9 providers in 6 countries. Built for AI agents.",
+  "description": "Open-source grocery infrastructure for humans and AI agents. Search live products and prices, compare retailers, build baskets and check out safely across supermarkets worldwide.",
   "type": "commonjs",
   "main": "dist/cli.js",
   "bin": {
+    "open-supermarkets": "dist/cli.js",
     "supermarket": "dist/cli.js",
     "supermarket-mcp": "dist/mcp-server.js",
     "supermarket-api": "dist/http-server.js",
@@ -30,14 +31,19 @@
     "shopping",
     "automation",
     "ai-agent",
+    "ai-agents",
     "mcp",
+    "mcp-server",
     "model-context-protocol",
+    "agent-skills",
     "cli",
     "tesco",
     "sainsburys",
     "ocado",
     "albert-heijn",
     "instacart",
+    "kroger",
+    "mercadona",
     "open-food-facts",
     "uk",
     "netherlands",
@@ -52,6 +58,20 @@
     "type": "git",
     "url": "git+https://github.com/abracadabra50/open-supermarkets.git"
   },
+  "homepage": "https://github.com/abracadabra50/open-supermarkets#readme",
+  "bugs": {
+    "url": "https://github.com/abracadabra50/open-supermarkets/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist",
+    "skills",
+    "SKILL.md",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "axios": "^1.6.0",
@@ -66,19 +86,5 @@
     "ts-node": "^10.9.0",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0"
-  },
-  "files": [
-    "dist",
-    "skills",
-    "SKILL.md",
-    "README.md",
-    "LICENSE"
-  ],
-  "homepage": "https://github.com/abracadabra50/open-supermarkets#readme",
-  "bugs": {
-    "url": "https://github.com/abracadabra50/open-supermarkets/issues"
-  },
-  "engines": {
-    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Why

Open Supermarkets already has real usage, external contributors and a strong technical core. This PR improves the conversion layer around it: explain the outcome faster, make the zero-install path obvious, tighten contributor/security hygiene, and give new provider contributions a clearer route into the project.

## What changes

### Positioning and README
- Reframes the project as the open-source grocery interface for humans and AI agents rather than primarily a CLI.
- Moves a zero-install `npx` path and agent use cases near the top.
- Makes CLI, HTTP, MCP and agent skills explicit surfaces.
- Adds a concrete end-to-end demo brief for the launch asset.
- Tightens the explanation of batch operations, safety boundaries, provider coverage and contribution model.
- Adds a `Built with Open Supermarkets` section to create a visible community/use-case loop.
- Fixes the stale provider/country contribution copy.

### npm/discovery
- Adds `open-supermarkets` as a binary alias so `npx open-supermarkets ...` works naturally.
- Keeps `supermarket` as the canonical CLI and the existing backwards-compatible aliases.
- Improves package description and discovery keywords.

### Community scaffolding
- Adds `CONTRIBUTING.md` with the provider verification contract and correctness rules.
- Adds `SECURITY.md` covering session material, checkout safety and responsible reporting.
- Adds provider-request and bug-report issue forms.
- Adds a PR template that forces live-vs-offline verification and capability/safety checks to be explicit.

## Deliberately not included

- PRs #18 and #19. They should be reviewed and merged independently rather than smuggled into a marketing/community PR.
- A fake demo asset. The README reserves the right spot and specifies the demo worth recording; the actual recording should show a real run.
- MCP Registry metadata. That should be added once the exact current registry schema/name is validated rather than guessing metadata into a release package.
- GitHub repository settings such as Discussions, social preview and homepage, which are repository-level configuration rather than source changes.
- Launch posts for Hacker News, Reddit, LinkedIn and Threads. Those should follow the release rather than live in the codebase.

## Verification

This PR is documentation/package metadata only; it does not alter provider or checkout implementation. CI should still run the existing Node 18/20/22 typecheck, build, test and package checks.

The package change intentionally adds one executable alias pointing at the existing `dist/cli.js`; no new runtime path is introduced.