### PR TITLE
fix(sainsburys): paginate favourites beyond first page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "setup": "./setup.sh",
     "supermarket": "tsx src/cli.ts",
     "prepublishOnly": "npm run build",
-    "test": "tsx test/lazy-loading.test.ts",
+    "test": "tsx test/lazy-loading.test.ts && tsx test/sainsburys-favourites.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/src/providers/sainsburys.ts
+++ b/src/providers/sainsburys.ts
@@ -142,21 +142,33 @@ export class SainsburysProvider implements GroceryProvider {
   }
 
   async getFavourites(options?: SearchOptions): Promise<Product[]> {
-    const response = await this.client.get('/product/v1/favourites', {
-      params: {
-        'include[ASSOCIATIONS]': 'true',
-        'include[REPLACEMENT_PRODUCTS]': 'true',
-        minimised: 'true',
-        store_identifier: this.storeNumber
-      },
-      headers: {
-        Referer: 'https://www.sainsburys.co.uk/gol-ui/favourites-as-list'
-      }
-    });
-
-    const products = (response.data.products || []).map((p: any) => this.mapProduct(p));
     const offset = options?.offset || 0;
     const limit = options?.limit;
+    const needed = typeof limit === 'number' ? offset + limit : Infinity;
+    const pageSize = 24;
+    const products: Product[] = [];
+
+    for (let page = 1; products.length < needed && page <= 100; page++) {
+      const response = await this.client.get('/product/v1/favourites', {
+        params: {
+          'include[ASSOCIATIONS]': 'true',
+          'include[REPLACEMENT_PRODUCTS]': 'true',
+          minimised: 'true',
+          store_identifier: this.storeNumber,
+          page_number: page,
+          page_size: pageSize
+        },
+        headers: {
+          Referer: 'https://www.sainsburys.co.uk/gol-ui/favourites-as-list'
+        }
+      });
+
+      const batch = (response.data.products || []).map((p: any) => this.mapProduct(p));
+      if (batch.length === 0) break;
+      products.push(...batch);
+      if (batch.length < pageSize) break;
+    }
+
     return typeof limit === 'number' ? products.slice(offset, offset + limit) : products.slice(offset);
   }
 

--- a/test/sainsburys-favourites.test.ts
+++ b/test/sainsburys-favourites.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Sainsbury's favourites must page through /product/v1/favourites.
+ *
+ * The live API defaults to one page of ~24 products — the same page_size
+ * search() already sends. Without page_number/page_size, both
+ * `supermarket favourites --limit 100` and fav-search only ever see that
+ * first page (issue #17).
+ *
+ * Run: npx tsx test/sainsburys-favourites.test.ts
+ */
+
+import assert from 'node:assert';
+import { SainsburysProvider } from '../src/providers/sainsburys';
+
+const PAGE_SIZE = 24;
+const TOTAL = 50;
+
+function rawProduct(i: number, name?: string) {
+  return {
+    product_uid: `fav-${i}`,
+    name: name ?? `Favourite item ${i}`,
+    retail_price: { price: 1.5 },
+    in_stock: true,
+  };
+}
+
+/** 50 favourites across three pages. Index 30 ("milk") lives on page 2. */
+function catalogue() {
+  const products = [];
+  for (let i = 0; i < TOTAL; i++) {
+    products.push(rawProduct(i, i === 30 ? 'Hidden Favourite Semi Skimmed Milk' : undefined));
+  }
+  return products;
+}
+
+function stubFavourites(provider: SainsburysProvider, captured: Array<{ url: string; params: Record<string, unknown> }>) {
+  const all = catalogue();
+  (provider as any).client.get = async (url: string, config: { params?: Record<string, unknown> }) => {
+    const params = { ...(config?.params || {}) };
+    captured.push({ url, params });
+    // Missing page_number → first page, matching the live API default.
+    const page = Number(params.page_number) || 1;
+    const size = Number(params.page_size) || PAGE_SIZE;
+    const start = (page - 1) * size;
+    return { data: { products: all.slice(start, start + size) } };
+  };
+}
+
+let failures = 0;
+async function check(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${err.message}`);
+  }
+}
+
+async function main() {
+  console.log('sainsburys favourites pagination');
+
+  await check('getFavourites walks pages so --limit 100 is not capped at 24', async () => {
+    const provider = new SainsburysProvider();
+    const captured: Array<{ url: string; params: Record<string, unknown> }> = [];
+    stubFavourites(provider, captured);
+
+    const products = await provider.getFavourites({ limit: 100 });
+    assert.strictEqual(
+      products.length,
+      TOTAL,
+      `expected all ${TOTAL} favourites, got ${products.length}`
+    );
+    assert.ok(
+      captured.every((c) => c.url === '/product/v1/favourites'),
+      `unexpected urls: ${captured.map((c) => c.url).join(', ')}`
+    );
+    assert.ok(
+      captured.some((c) => Number(c.params.page_number) >= 2),
+      `expected a request with page_number>=2, got ${JSON.stringify(captured.map((c) => c.params))}`
+    );
+    assert.ok(
+      captured.every((c) => c.params.page_size != null),
+      'each favourites request must send page_size (same as search())'
+    );
+    assert.strictEqual(products[30].product_uid, 'fav-30');
+    assert.strictEqual(products[30].name, 'Hidden Favourite Semi Skimmed Milk');
+  });
+
+  await check('searchFavourites sees a match that only exists on page 2', async () => {
+    const provider = new SainsburysProvider();
+    const captured: Array<{ url: string; params: Record<string, unknown> }> = [];
+    stubFavourites(provider, captured);
+
+    const hits = await provider.searchFavourites('semi skimmed milk');
+    assert.strictEqual(
+      hits.length,
+      1,
+      `expected the page-2 milk favourite, got ${hits.map((p) => p.name).join(', ') || 'none'}`
+    );
+    assert.strictEqual(hits[0].product_uid, 'fav-30');
+  });
+
+  console.log(failures === 0 ? '\nall passed' : `\n${failures} failed`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## What changed

Sainsbury's `getFavourites()` called `/product/v1/favourites` with no `page_number` / `page_size`, so the API returned a single page of ~24 products. Client-side `offset`/`limit` only sliced that page. `searchFavourites()` calls `getFavourites()` with no options, so `supermarket fav-search` never saw anything past page 1.

This paginates the same way `search()` already does: send `page_number`/`page_size` and loop until a page is empty or short, so `supermarket favourites --limit 100` and fav-search can see the rest of the list.

Reported by @geftactics.

Fixes #17

## Verification

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`

### Live verification

Not tested live — no Sainsbury's credentials in this environment.

### Offline verification

Stubbed `client.get` to return 50 favourites across three pages (page 2 holds a "milk" product). On unmodified `main`, `getFavourites({ limit: 100 })` returned 24 and `searchFavourites('semi skimmed milk')` missed that match. After this change both pass. Existing `npm test` suite still green.

## Capability / safety review

- [x] The provider only declares capabilities that are actually implemented.
- [x] Unknown stock/pricing/state is preserved rather than invented.
- [x] Checkout or other spend paths remain preview/dry-run by default.
- [x] No credentials, cookies, addresses, payment data or private order data are included.
- [x] Upstream protocol/research sources are credited where relevant.

## Known limitations

Uses the same default `page_size` of 24 as `search()`. The loop stops on an empty or short page, or after 100 pages as a backstop. Not exercised against the live favourites API in this PR.
